### PR TITLE
Fix to avoid Mono 3 xbuild bug

### DIFF
--- a/bld/build.mono.proj
+++ b/bld/build.mono.proj
@@ -25,13 +25,18 @@
 
 
 	<ItemGroup>
+		<!-- We would like to Include "$(RootDir)/**/obj/**/*" as well, but the Mono 3 xbuild -->
+		<!-- treats that pattern the same as "$(RootDir)/**/*", which has unfortunate results! -->
 		<ExistingObjectFiles
-			Include="$(RootDir)/**/obj/**/*;$(RootDir)/output/$(Configuration)/**/*"
-			Exclude="$(RootDir)/.hg/**/*"
+			Include="$(RootDir)/output/$(Configuration)/**/*"
+			Exclude="$(RootDir)/.hg/**/*;$(RootDir)/.git/**/*"
 		/>
 	</ItemGroup>
 	<Target Name="Clean">
 		<Delete Files="@(ExistingObjectFiles)" />
+		<Exec
+			Command="find . -path '*/obj/$(Configuration)' -type d -print0 | xargs -0 rm -rvf"
+			WorkingDirectory="$(RootDir)" />
 	</Target>
 
 	<Target Name="Compile">


### PR DESCRIPTION
This is needed for Ubuntu trusty since it comes with Mono 3.2 instead
of Mono 2.10.
