### PR TITLE
Add ability to get boundaries (for words and uncategorized words)

### DIFF
--- a/source/icu.net.tests/BreakIteratorTests.cs
+++ b/source/icu.net.tests/BreakIteratorTests.cs
@@ -95,17 +95,21 @@ namespace Icu.Tests
 		}
 
 		[Test]
-		public void GetWordBoundaries()
+		public void GetWordBoundaries_IgnoreSpacesAndPunctuation()
 		{
 			var onlyWords = BreakIterator.GetWordBoundaries(new Locale("en-US"), WordBoundaryTestData.Text, false);
-			var allBoundaries = BreakIterator.GetWordBoundaries(new Locale("en-US"), WordBoundaryTestData.Text, true);
 
 			Assert.That(onlyWords.Count(), Is.EqualTo(WordBoundaryTestData.ExpectedOnlyWords.Length));
 			Assert.That(onlyWords.ToArray(), Is.EquivalentTo(WordBoundaryTestData.ExpectedOnlyWords));
+		}
+
+		[Test]
+		public void GetWordBoundaries_IncludeSpacesAndPunctuation()
+		{
+			var allBoundaries = BreakIterator.GetWordBoundaries(new Locale("en-US"), WordBoundaryTestData.Text, true);
 
 			Assert.That(allBoundaries.Count(), Is.EqualTo(WordBoundaryTestData.ExpectedAllBoundaries.Length));
 			Assert.That(allBoundaries.ToArray(), Is.EquivalentTo(WordBoundaryTestData.ExpectedAllBoundaries));
-
 		}
 
 		/// <summary>

--- a/source/icu.net.tests/BreakIteratorTests.cs
+++ b/source/icu.net.tests/BreakIteratorTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) 2013 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
-using System;
 using System.Linq;
 using NUnit.Framework;
 
@@ -41,6 +40,119 @@ namespace Icu.Tests
 			var parts = BreakIterator.Split(BreakIterator.UBreakIteratorType.SENTENCE, "en-US", "Aa bb. Cc 3.5 x? Y?x! Z");
 			Assert.That(parts.ToArray(), Is.EquivalentTo(new[] { "Aa bb. ", "Cc 3.5 x? ", "Y?", "x! ","Z"}));
 			Assert.That(parts.Count(), Is.EqualTo(5));
+		}
+
+		[Test]
+		public void GetBoundaries_Character()
+		{
+			var text = "abc? 1";
+			var expected = new[] {
+				new Boundary(0, 1), new Boundary(1, 2), new Boundary(2, 3), new Boundary(3, 4), new Boundary(4, 5), new Boundary(5, 6)
+			};
+
+			var parts = BreakIterator.GetBoundaries(BreakIterator.UBreakIteratorType.CHARACTER, new Locale("en-US"), text);
+
+			Assert.That(parts.Count(), Is.EqualTo(expected.Length));
+			Assert.That(parts.ToArray(), Is.EquivalentTo(expected));
+		}
+
+		[Test]
+		public void GetBoundaries_Word()
+		{
+			var parts = BreakIterator.GetBoundaries(BreakIterator.UBreakIteratorType.WORD, new Locale("en-US"), WordBoundaryTestData.Text);
+
+			Assert.That(parts.Count(), Is.EqualTo(WordBoundaryTestData.ExpectedOnlyWords.Length));
+			Assert.That(parts.ToArray(), Is.EquivalentTo(WordBoundaryTestData.ExpectedOnlyWords));
+		}
+
+		[Test]
+		public void GetBoundaries_Line()
+		{
+			var text = "Aa bb. Ccdef 3.5 x? Y?x! Z";
+			var expected = new[] {
+				new Boundary(0, 3), new Boundary(3, 7), new Boundary(7, 13), new Boundary(13, 17), new Boundary(17, 20),
+				new Boundary(20, 22), new Boundary(22, 25), new Boundary(25, 26)
+			};
+
+			var parts = BreakIterator.GetBoundaries(BreakIterator.UBreakIteratorType.LINE, new Locale("en-US"), text);
+
+			Assert.That(parts.Count(), Is.EqualTo(expected.Length));
+			Assert.That(parts.ToArray(), Is.EquivalentTo(expected));
+		}
+
+		[Test]
+		public void GetBoundaries_Sentence()
+		{
+			var text = "Aa bb. Ccdef 3.5 x? Y?x! Z";
+			var expected = new[] {
+				new Boundary(0, 7), new Boundary(7, 20), new Boundary(20, 22), new Boundary(22, 25), new Boundary(25, 26)
+			};
+
+			var parts = BreakIterator.GetBoundaries(BreakIterator.UBreakIteratorType.SENTENCE, new Locale("en-US"), text);
+			
+			Assert.That(parts.Count(), Is.EqualTo(expected.Length));
+			Assert.That(parts.ToArray(), Is.EquivalentTo(expected));
+		}
+
+		[Test]
+		public void GetWordBoundaries()
+		{
+			var onlyWords = BreakIterator.GetWordBoundaries(new Locale("en-US"), WordBoundaryTestData.Text, false);
+			var allBoundaries = BreakIterator.GetWordBoundaries(new Locale("en-US"), WordBoundaryTestData.Text, true);
+
+			Assert.That(onlyWords.Count(), Is.EqualTo(WordBoundaryTestData.ExpectedOnlyWords.Length));
+			Assert.That(onlyWords.ToArray(), Is.EquivalentTo(WordBoundaryTestData.ExpectedOnlyWords));
+
+			Assert.That(allBoundaries.Count(), Is.EqualTo(WordBoundaryTestData.ExpectedAllBoundaries.Length));
+			Assert.That(allBoundaries.ToArray(), Is.EquivalentTo(WordBoundaryTestData.ExpectedAllBoundaries));
+
+		}
+
+		/// <summary>
+		/// The hypenated text case tests the difference between Word and Line
+		/// breaks described in:
+		/// http://userguide.icu-project.org/boundaryanalysis#TOC-Line-break-Boundary
+		/// </summary>
+		[Test]
+		public void GetWordAndLineBoundariesWithHyphenatedText()
+		{
+			var text = "Good-day, kind sir !";
+			var expectedWords = new[] {
+				new Boundary(0, 4), new Boundary(5, 8), new Boundary(10, 14), new Boundary(15, 18)
+			};
+			var expectedLines = new[] {
+				new Boundary(0, 5), new Boundary(5, 10), new Boundary(10, 15), new Boundary(15, 20)
+			};
+
+			var wordBoundaries = BreakIterator.GetBoundaries(BreakIterator.UBreakIteratorType.WORD, new Locale("en-US"), text);
+			var lineBoundaries = BreakIterator.GetBoundaries(BreakIterator.UBreakIteratorType.LINE, new Locale("en-US"), text);
+
+			Assert.That(wordBoundaries.Count(), Is.EqualTo(expectedWords.Length));
+			Assert.That(wordBoundaries.ToArray(), Is.EquivalentTo(expectedWords));
+
+			Assert.That(lineBoundaries.Count(), Is.EqualTo(expectedLines.Length));
+			Assert.That(lineBoundaries.ToArray(), Is.EquivalentTo(expectedLines));
+		}
+
+		/// <summary>
+		/// Test data for GetBoundaries_Word and GetWordBoundaries  tests
+		/// </summary>
+		internal static class WordBoundaryTestData
+		{
+			public const string Text = "Aa bb. Ccdef 3.5 x? Y?x! Z";
+
+			public static readonly Boundary[] ExpectedOnlyWords = new[] {
+				new Boundary(0, 2), new Boundary(3, 5), new Boundary(7, 12), new Boundary(13, 16),
+				new Boundary(17, 18), new Boundary(20, 21), new Boundary(22, 23), new Boundary(25, 26)
+			};
+
+			public static readonly Boundary[] ExpectedAllBoundaries = new[] {
+				new Boundary(0, 2), new Boundary(2, 3), new Boundary(3, 5), new Boundary(5, 6),
+				new Boundary(6, 7), new Boundary(7, 12), new Boundary(12, 13), new Boundary(13, 16),
+				new Boundary(16, 17), new Boundary(17, 18), new Boundary(18, 19), new Boundary(19, 20),
+				new Boundary(20, 21), new Boundary(21, 22), new Boundary(22, 23), new Boundary(23, 24),
+				new Boundary(24, 25), new Boundary(25, 26)
+			};
 		}
 	}
 }

--- a/source/icu.net/Boundary.cs
+++ b/source/icu.net/Boundary.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+namespace Icu
+{
+	/// <summary>
+	/// Specifies the start and end indexes of a word, line, sentence or character.
+	/// </summary>
+	public struct Boundary
+	{
+		/// <summary>
+		/// Starting index of a boundary
+		/// </summary>
+		public int Start;
+
+		/// <summary>
+		/// End index of a boundary
+		/// </summary>
+		public int End;
+
+		/// <summary>
+		/// Creates a boundary with the specified start and end. The word would lie
+		/// between indices x, Start <= x < End
+		/// </summary>
+		public Boundary(int start, int end)
+		{
+			if (start > end)
+			{
+				throw new ArgumentException("start index cannot be greater than the end index.");
+			}
+
+			Start = start;
+			End = end;
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (!(obj is Boundary))
+			{
+				return false;
+			}
+
+			var compared = (Boundary)obj;
+
+			return Start == compared.Start && End == compared.End;
+		}
+
+		public override int GetHashCode()
+		{
+			return base.GetHashCode();
+		}
+
+		public override string ToString()
+		{
+			return string.Format("Start: [{0}], End: [{1}]", Start, End);
+		}
+	}
+}

--- a/source/icu.net/Boundary.cs
+++ b/source/icu.net/Boundary.cs
@@ -5,17 +5,17 @@ namespace Icu
 	/// <summary>
 	/// Specifies the start and end indexes of a word, line, sentence or character.
 	/// </summary>
-	public struct Boundary
+	public class Boundary
 	{
 		/// <summary>
 		/// Starting index of a boundary
 		/// </summary>
-		public int Start;
+		public readonly int Start;
 
 		/// <summary>
 		/// End index of a boundary
 		/// </summary>
-		public int End;
+		public readonly int End;
 
 		/// <summary>
 		/// Creates a boundary with the specified start and end. The word would lie
@@ -34,14 +34,11 @@ namespace Icu
 
 		public override bool Equals(object obj)
 		{
-			if (!(obj is Boundary))
-			{
-				return false;
-			}
+			var compared = obj as Boundary;
 
-			var compared = (Boundary)obj;
-
-			return Start == compared.Start && End == compared.End;
+			return compared != null 
+				&& Start == compared.Start 
+				&& End == compared.End;
 		}
 
 		public override int GetHashCode()

--- a/source/icu.net/BreakIterator.cs
+++ b/source/icu.net/BreakIterator.cs
@@ -95,8 +95,11 @@ namespace Icu
 		/// <summary>
 		/// Gets word boundaries for given text.
 		/// </summary>
-		/// <param name="includeSpacesAndPunctuation">true to include spaces and punctuation in the
-		/// boundaries; false otherwise.</param>
+		/// <param name="includeSpacesAndPunctuation">ICU's UBreakIteratorType.WORD analysis considers
+		/// spaces and punctuation as boundaries for words. Set parameter to true if all boundaries
+		/// are desired; false otherwise.
+		/// For more information: http://userguide.icu-project.org/boundaryanalysis#TOC-Count-the-words-in-a-document-C-only-:
+		/// </param>
 		public static IEnumerable<Boundary> GetWordBoundaries(Locale locale, string text, bool includeSpacesAndPunctuation)
 		{
 			return GetWordBoundaries(locale.Id, text, includeSpacesAndPunctuation);

--- a/source/icu.net/BreakIterator.cs
+++ b/source/icu.net/BreakIterator.cs
@@ -6,9 +6,8 @@ using System.Linq;
 
 namespace Icu
 {
-	public class BreakIterator
+	public static class BreakIterator
 	{
-
 		/// <summary>
 		/// The possible types of text boundaries.
 		/// </summary>
@@ -85,24 +84,69 @@ namespace Icu
 		public static IEnumerable<string> Split(UBreakIteratorType type, string locale, string text)
 		{
 			if (string.IsNullOrEmpty(text))
-				return Enumerable.Empty<string>();
+				yield break;
+
+			foreach (var boundary in GetBoundaries(type, locale, text, includeSpacesAndPunctuation: false))
+			{
+				yield return text.Substring(boundary.Start, boundary.End - boundary.Start);
+			}
+		}
+
+		/// <summary>
+		/// Gets word boundaries for given text.
+		/// </summary>
+		/// <param name="includeSpacesAndPunctuation">true to include spaces and punctuation in the
+		/// boundaries; false otherwise.</param>
+		public static IEnumerable<Boundary> GetWordBoundaries(Locale locale, string text, bool includeSpacesAndPunctuation)
+		{
+			return GetWordBoundaries(locale.Id, text, includeSpacesAndPunctuation);
+		}
+
+		public static IEnumerable<Boundary> GetWordBoundaries(string locale, string text, bool includeSpacesAndPunctuation)
+		{
+			return GetBoundaries(UBreakIteratorType.WORD, locale, text, includeSpacesAndPunctuation);
+		}
+
+		/// <summary>
+		/// Gets the sentence/line/word/character boundaries for the text. Spaces and punctuations
+		/// are not returned for UBreakIteratorType.WORD.
+		/// </summary>
+		public static IEnumerable<Boundary> GetBoundaries(UBreakIteratorType type, Locale locale, string text)
+		{
+			return GetBoundaries(type, locale.Id, text, false);
+		}
+
+		private static IEnumerable<Boundary> GetBoundaries(UBreakIteratorType type, string locale, string text, bool includeSpacesAndPunctuation)
+		{
+			if (string.IsNullOrEmpty(text))
+				yield break;
 
 			ErrorCode err;
 			IntPtr bi = NativeMethods.ubrk_open(type, locale, text, text.Length, out err);
 			if (err != ErrorCode.NoErrors)
 				throw new Exception("BreakIterator.Split() failed with code " + err);
-			var tokens = new List<string>();
+
 			int cur = NativeMethods.ubrk_first(bi);
+
 			while (cur != DONE)
 			{
 				int next = NativeMethods.ubrk_next(bi);
 				int status = NativeMethods.ubrk_getRuleStatus(bi);
-				if (next != DONE && AddToken(type, status))
-					tokens.Add(text.Substring(cur, next - cur));
+				
+				if (next == DONE)
+				{
+					break;
+				}
+
+				if (includeSpacesAndPunctuation || AddToken(type, status))
+				{
+					yield return new Boundary(cur, next);
+				}
+
 				cur = next;
 			}
+
 			NativeMethods.ubrk_close(bi);
-			return tokens;
 		}
 
 		private static bool AddToken(UBreakIteratorType type, int status)
@@ -119,6 +163,5 @@ namespace Icu
 			}
 			return false;
 		}
-
 	}
 }

--- a/source/icu.net/icu.net.csproj
+++ b/source/icu.net/icu.net.csproj
@@ -144,6 +144,7 @@
 	<Compile Include="UnicodeSet.cs" />
 	<Compile Include="Normalizer.cs" />
 	<Compile Include="BreakIterator.cs" />
+	<Compile Include="Boundary.cs" />
   </ItemGroup>
   <ItemGroup>
 	<None Include="App.config" />


### PR DESCRIPTION
The existing `BreakIterator.Split` method returns strings. This is a problem when you want use the returned string token within a larger piece of text because Windows and icu have different collation implementations.  This results in weird behaviour such as [dotnet/corefx#9202](https://github.com/dotnet/corefx/issues/9202).

This also adds the option to return non-categorized word boundaries such as punctuation and spaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/9)
<!-- Reviewable:end -->
