### PR TITLE
Adding ability to build icu nuget package

### DIFF
--- a/bld/nuget/Install.ps1
+++ b/bld/nuget/Install.ps1
@@ -1,0 +1,20 @@
+param($installPath, $toolsPath, $package, $project)
+
+$icuRegex = "icu(dt|in|uc)[0-9]+\.dll"
+
+foreach ($dll in $project.ProjectItems) {
+
+    if ($dll.Name -notmatch $icuRegex) {
+        continue
+    }
+
+    # Setting BuildAction = None
+    # Reference: http://stackoverflow.com/a/7427431/4220757
+    $buildAction = $dll.Properties.Item("BuildAction")
+    $buildAction.Value = 0
+    
+    # Set CopyToOutputDirectory to "Copy if Newer"
+    # Reference: http://stackoverflow.com/questions/23503145/why-does-the-verbiage-for-the-copy-to-output-directory-selection-change-betwee/23511515#23511515
+    $copyToOutput = $dll.Properties.Item("CopyToOutputDirectory")
+    $copyToOutput.Value = 2
+}

--- a/bld/nuget/icu.net.nuspec
+++ b/bld/nuget/icu.net.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>icu-dotnet</id>
+    <version>1.2.0</version>
+    <authors>SIL International</authors>
+    <licenseUrl>https://github.com/sillsdev/icu-dotnet/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/sillsdev/icu-dotnet</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>C# Wrapper around ICU4C</description>
+    <dependencies>
+      <group targetFramework="net40" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\..\output\$configuration$\icu.net.dll" target="lib\net40" />
+    <file src="..\..\output\$configuration$\icu.net.dll.config" target="lib\net40" />
+    
+    <file src="..\..\lib\icu\*.dll" target="content" />
+    <file src="Install.ps1" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
This adds the ability to create a nuget package.  There still needs to be some manual steps to be done in order to incorporate this into your build system.

**Example:** 
`nuget.exe pack bld\nuget\icu.net.nuspec -Version $(VERSION_NUMBER) -Prop Configuration=$(Configuration)`

**Manual Steps**
1. Add [nuget pack](https://confluence.jetbrains.com/display/TCD9/NuGet+Pack) publish step to build
2. Someone would have to publish the nuget package. 
    1. It could be added as a [publish step](https://confluence.jetbrains.com/display/TCD9/NuGet+Publish) in a release build.
    2. Someone could manually upload a package on [nuget.org](https://www.nuget.org/)

Fixes #7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/10)
<!-- Reviewable:end -->
