### PR TITLE
Dynamically load unmanaged ICU library

### DIFF
--- a/source/icu.net/Character.cs
+++ b/source/icu.net/Character.cs
@@ -406,7 +406,7 @@ namespace Icu
 			try
 			{
 				ErrorCode error;
-				int nResult = NativeMethods.u_CharName(code, nameChoice, resPtr, nSize, out error);
+				int nResult = NativeMethods.u_charName(code, nameChoice, resPtr, nSize, out error);
 				if (error != ErrorCode.NoErrors)
 				{
 					nResult = -1;

--- a/source/icu.net/NativeMethods.cs
+++ b/source/icu.net/NativeMethods.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2013 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using Icu.Collation;
 
@@ -8,95 +9,183 @@ namespace Icu
 {
 	internal static class NativeMethods
 	{
-		#if ICU_VER_40
-		internal const string ICU_I18N_LIB = "icuin40.dll";
-		internal const string ICU_COMMON_LIB = "icuuc40.dll";
-		internal const string ICU_VERSION_SUFFIX = "_4_0";
-		#elif ICU_VER_48
-		internal const string ICU_I18N_LIB = "icuin48.dll";
-		internal const string ICU_COMMON_LIB = "icuuc48.dll";
-		internal const string ICU_VERSION_SUFFIX = "_48";
-		#elif ICU_VER_49
-		internal const string ICU_I18N_LIB = "icuin49.dll";
-		internal const string ICU_COMMON_LIB = "icuuc49.dll";
-		internal const string ICU_VERSION_SUFFIX = "_49";
-		#elif ICU_VER_50
-		internal const string ICU_I18N_LIB = "icuin50.dll";
-		internal const string ICU_COMMON_LIB = "icuuc50.dll";
-		internal const string ICU_VERSION_SUFFIX = "_50";
-		#elif ICU_VER_51
-		internal const string ICU_I18N_LIB = "icuin51.dll";
-		internal const string ICU_COMMON_LIB = "icuuc51.dll";
-		internal const string ICU_VERSION_SUFFIX = "_51";
-		#elif ICU_VER_52
-		internal const string ICU_I18N_LIB = "icuin52.dll";
-		internal const string ICU_COMMON_LIB = "icuuc52.dll";
-		internal const string ICU_VERSION_SUFFIX = "_52";
-		#elif ICU_VER_53
-		internal const string ICU_I18N_LIB = "icuin53.dll";
-		internal const string ICU_COMMON_LIB = "icuuc53.dll";
-		internal const string ICU_VERSION_SUFFIX = "_53";
-		#elif ICU_VER_54
-		internal const string ICU_I18N_LIB = "icuin54.dll";
-		internal const string ICU_COMMON_LIB = "icuuc54.dll";
-		internal const string ICU_VERSION_SUFFIX = "_54";
-		#elif ICU_VER_55
-		internal const string ICU_I18N_LIB = "icuin55.dll";
-		internal const string ICU_COMMON_LIB = "icuuc55.dll";
-		internal const string ICU_VERSION_SUFFIX = "_55";
-		#elif ICU_VER_56
-		internal const string ICU_I18N_LIB = "icuin56.dll";
-		internal const string ICU_COMMON_LIB = "icuuc56.dll";
-		internal const string ICU_VERSION_SUFFIX = "_56";
-		#elif ICU_VER_57
-		internal const string ICU_I18N_LIB = "icuin57.dll";
-		internal const string ICU_COMMON_LIB = "icuuc57.dll";
-		internal const string ICU_VERSION_SUFFIX = "_57";
-		#elif ICU_VER_58
-		internal const string ICU_I18N_LIB = "icuin58.dll";
-		internal const string ICU_COMMON_LIB = "icuuc58.dll";
-		internal const string ICU_VERSION_SUFFIX = "_58";
-		#elif ICU_VER_569
-		internal const string ICU_I18N_LIB = "icuin59.dll";
-		internal const string ICU_COMMON_LIB = "icuuc59.dll";
-		internal const string ICU_VERSION_SUFFIX = "_59";
-		#elif ICU_VER_60
-		internal const string ICU_I18N_LIB = "icuin60.dll";
-		internal const string ICU_COMMON_LIB = "icuuc60.dll";
-		internal const string ICU_VERSION_SUFFIX = "_60";
-		#else
-		#error We need to update the code for newer version of ICU after 60 (or older version before 4.8)
-		#endif
+		private const int minIcuVersion = 44;
+		private const int maxIcuVersion = 60;
 
-		/**
-			 * Function type declaration for uenum_close().
-			 *
-			 * This function should cleanup the enumerator object
-			 *
-			 * @param en enumeration to be closed
-			 */
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uenum_close" + ICU_VERSION_SUFFIX, CallingConvention = CallingConvention.Cdecl)]
-		public static extern void uenum_close(IntPtr en);
+		#region Dynamic method loading
 
-		/**
-			 * Function type declaration for uenum_unext().
-			 *
-			 * This function returns the next element as a UChar *,
-			 * or NULL after all elements haven been enumerated.
-			 *
-			 * @param en enumeration
-			 * @param resultLength pointer to result length
-			 * @param status pointer to ErrorCode variable
-			 * @return next element as UChar *,
-			 *         or NULL after all elements haven been enumerated
-			 */
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uenum_unext" + ICU_VERSION_SUFFIX, CallingConvention = CallingConvention.Cdecl)]
-		public static extern IntPtr uenum_unext(
+		#region Native methods for Linux
+
+		private const int RTLD_NOW = 2;
+
+		[DllImport("libdl.so")]
+		private static extern IntPtr dlopen([MarshalAs(UnmanagedType.LPTStr)] string file, int mode);
+
+		[DllImport("libdl.so")]
+		private static extern int dlclose(IntPtr handle);
+
+		[DllImport("libdl.so")]
+		private static extern IntPtr dlsym(IntPtr handle, [MarshalAs(UnmanagedType.LPTStr)] string name);
+
+		#endregion
+
+		#region Native methods for Windows
+
+		[DllImport("kernel32.dll")]
+		private static extern IntPtr LoadLibrary(string dllToLoad);
+
+		[DllImport("kernel32.dll")]
+		private static extern bool FreeLibrary(IntPtr hModule);
+
+		[DllImport("kernel32.dll")]
+		private static extern IntPtr GetProcAddress(IntPtr hModule, string procedureName);
+
+		#endregion
+
+		private static int IcuVersion;
+		private static IntPtr _IcuCommonLibHandle;
+		private static IntPtr _IcuI18NLibHandle;
+
+		private static bool IsWindows
+		{
+			get { return Environment.OSVersion.Platform != PlatformID.Unix; }
+		}
+
+		private static IntPtr IcuCommonLibHandle
+		{
+			get
+			{
+				if (_IcuCommonLibHandle == IntPtr.Zero)
+					_IcuCommonLibHandle = LoadIcuLibrary("icuuc");
+				return _IcuCommonLibHandle;
+			}
+		}
+
+		private static IntPtr IcuI18NLibHandle
+		{
+			get
+			{
+				if (_IcuI18NLibHandle == IntPtr.Zero)
+					_IcuI18NLibHandle = LoadIcuLibrary(IsWindows ? "icuin" : "icui18n");
+				return _IcuI18NLibHandle;
+			}
+		}
+
+		private static IntPtr LoadIcuLibrary(string libraryName)
+		{
+			var handle = GetIcuLibHandle(libraryName, IcuVersion > 0 ? IcuVersion : maxIcuVersion);
+			if (handle == IntPtr.Zero)
+				throw new FileLoadException("Can't load ICU library", libraryName);
+			return handle;
+		}
+
+		private static IntPtr GetIcuLibHandle(string basename, int icuVersion)
+		{
+			if (icuVersion < minIcuVersion)
+				return IntPtr.Zero;
+			IntPtr handle;
+			if (IsWindows)
+			{
+				handle = LoadLibrary(string.Format("{0}{1}.dll", basename, icuVersion));
+			}
+			else
+			{
+				var libName = string.Format("lib{0}.so.{1}", basename, icuVersion);
+				handle = dlopen(libName, RTLD_NOW);
+			}
+			if (handle == IntPtr.Zero)
+				return GetIcuLibHandle(basename, icuVersion - 1);
+
+			IcuVersion = icuVersion;
+			return handle;
+		}
+
+		public static void Cleanup()
+		{
+			if (IsWindows)
+			{
+				if (_IcuCommonLibHandle != IntPtr.Zero)
+					FreeLibrary(_IcuCommonLibHandle);
+				if (_IcuI18NLibHandle != IntPtr.Zero)
+					FreeLibrary(_IcuI18NLibHandle);
+			}
+			else
+			{
+				if (_IcuCommonLibHandle != IntPtr.Zero)
+					dlclose(_IcuCommonLibHandle);
+				if (_IcuI18NLibHandle != IntPtr.Zero)
+					dlclose(_IcuI18NLibHandle);
+			}
+			_IcuCommonLibHandle = IntPtr.Zero;
+			_IcuI18NLibHandle = IntPtr.Zero;
+		}
+
+		private static T GetMethod<T>(IntPtr handle, string methodName) where T: class
+		{
+			var versionedMethodName = string.Format("{0}_{1}", methodName, IcuVersion);
+			var methodPointer = IsWindows ?
+				GetProcAddress(handle, versionedMethodName) :
+				dlsym(handle, versionedMethodName);
+			if (methodPointer != IntPtr.Zero)
+			{
+				return Marshal.GetDelegateForFunctionPointer(
+					methodPointer, typeof(T)) as T;
+			}
+			return default(T);
+		}
+
+		#endregion
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate void uenum_closeDelegate(IntPtr en);
+
+		private static uenum_closeDelegate _uenum_close;
+
+		/// <summary>
+		/// This function does cleanup of the enumerator object
+		/// </summary>
+		/// <param name="en">Enumeration to be closed</param>
+		public static void uenum_close(IntPtr en)
+		{
+			if (_uenum_close == null)
+				_uenum_close = GetMethod<uenum_closeDelegate>(IcuCommonLibHandle, "uenum_close");
+			_uenum_close(en);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate IntPtr uenum_unextDelegate(
 			RuleBasedCollator.SafeEnumeratorHandle en,
 			out int resultLength,
 			out ErrorCode status);
 
+		private static uenum_unextDelegate _uenum_unext;
+
+		/// <summary>
+		/// This function returns the next element as a string, or <c>null</c> after all
+		/// elements haven been enumerated.
+		/// </summary>
+		/// <returns>next element as string, or <c>null</c> after all elements haven been
+		/// enumerated</returns>
+		public static IntPtr uenum_unext(
+			RuleBasedCollator.SafeEnumeratorHandle en,
+			out int resultLength,
+			out ErrorCode status)
+		{
+			if (_uenum_unext == null)
+				_uenum_unext = GetMethod<uenum_unextDelegate>(IcuCommonLibHandle, "uenum_unext");
+			return _uenum_unext(en, out resultLength, out status);
+		}
+
+
 		#region Unicode collator
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate RuleBasedCollator.SafeRuleBasedCollatorHandle ucol_openDelegate(
+			[MarshalAs(UnmanagedType.LPStr)] string loc,
+			out ErrorCode status);
+
+		private static ucol_openDelegate _ucol_open;
+
 		/// <summary>
 		/// Open a Collator for comparing strings.
 		/// Collator pointer is used in all the calls to the Collation
@@ -110,19 +199,44 @@ namespace Icu
 		/// <param name="status">A pointer to an ErrorCode to receive any errors
 		///</param>
 		/// <returns>pointer to a Collator or 0 if an error occurred</returns>
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_open" + ICU_VERSION_SUFFIX, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern RuleBasedCollator.SafeRuleBasedCollatorHandle ucol_open(
+		public static RuleBasedCollator.SafeRuleBasedCollatorHandle ucol_open(
 			[MarshalAs(UnmanagedType.LPStr)] string loc,
-			out ErrorCode status);
+			out ErrorCode status)
+		{
+			if (_ucol_open == null)
+				_ucol_open = GetMethod<ucol_openDelegate>(IcuI18NLibHandle, "ucol_open");
+			return _ucol_open(loc, out status);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate RuleBasedCollator.SafeRuleBasedCollatorHandle ucol_openDelegate2(
+			byte[] loc,
+			out ErrorCode err);
+
+		private static ucol_openDelegate2 _ucol_open2;
 
 		/// <summary>
 		/// Open a UCollator for comparing strings.
 		/// </summary>
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_open" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern RuleBasedCollator.SafeRuleBasedCollatorHandle ucol_open(
+		public static RuleBasedCollator.SafeRuleBasedCollatorHandle ucol_open(
 			byte[] loc,
-			out ErrorCode err);
+			out ErrorCode err)
+		{
+			if (_ucol_open2 == null)
+				_ucol_open2 = GetMethod<ucol_openDelegate2>(IcuI18NLibHandle, "ucol_open");
+			return _ucol_open2(loc, out err);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate RuleBasedCollator.SafeRuleBasedCollatorHandle ucol_openRulesDelegate(
+			[MarshalAs(UnmanagedType.LPWStr)] string rules,
+			int rulesLength,
+			NormalizationMode normalizationMode,
+			CollationStrength strength,
+			ref ParseError parseError,
+			out ErrorCode status);
+
+		private static ucol_openRulesDelegate _ucol_openRules;
 
 		///<summary>
 		/// Produce an Collator instance according to the rules supplied.
@@ -141,14 +255,19 @@ namespace Icu
 		/// <param name="status">A pointer to an ErrorCode to receive any errors</param>
 		/// <returns>A pointer to a UCollator. It is not guaranteed that NULL be returned in case
 		///         of error - please use status argument to check for errors.</returns>
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_openRules" + ICU_VERSION_SUFFIX, CallingConvention = CallingConvention.Cdecl)]
-		public static extern RuleBasedCollator.SafeRuleBasedCollatorHandle ucol_openRules(
+		public static RuleBasedCollator.SafeRuleBasedCollatorHandle ucol_openRules(
 			[MarshalAs(UnmanagedType.LPWStr)] string rules,
 			int rulesLength,
 			NormalizationMode normalizationMode,
 			CollationStrength strength,
 			ref ParseError parseError,
-			out ErrorCode status);
+			out ErrorCode status)
+		{
+			if (_ucol_openRules == null)
+				_ucol_openRules = GetMethod<ucol_openRulesDelegate>(IcuI18NLibHandle, "ucol_openRules");
+			return _ucol_openRules(rules, rulesLength, normalizationMode, strength, ref parseError,
+				out status);
+		}
 
 		/**
  * Open a collator defined by a short form string.
@@ -186,25 +305,47 @@ namespace Icu
  */
 
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_openFromShortString"+ICU_VERSION_SUFFIX))]
-			public static extern SafeRuleBasedCollatorHandle ucol_openFromShortString(
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate SafeRuleBasedCollatorHandle ucol_openFromShortStringDelegate(
 					[MarshalAs(UnmanagedType.LPStr)] string definition,
 					[MarshalAs(UnmanagedType.I1)] bool forceDefaults,
 					ref ParseError parseError,
 					out ErrorCode status);
+			private static ucol_openFromShortStringDelegate _ucol_openFromShortString;
+
+			public static SafeRuleBasedCollatorHandle ucol_openFromShortString(
+					[MarshalAs(UnmanagedType.LPStr)] string definition,
+					[MarshalAs(UnmanagedType.I1)] bool forceDefaults,
+					ref ParseError parseError,
+					out ErrorCode status)
+			{
+			if (_ucol_openFromShortString == null)
+			_ucol_openFromShortString = GetMethod<ucol_openFromShortStringDelegate>(IcuI18NLibHandle, "ucol_openFromShortString");
+			return _ucol_openFromShortString(
+					[MarshalAs(UnmanagedType.LPStr)] string definition,
+					[MarshalAs(UnmanagedType.I1)] bool forceDefaults,
+					ref ParseError parseError,
+					out ErrorCode status);
+			};
 			*/
 
-		/**
- * Close a UCollator.
- * Once closed, a UCollator should not be used. Every open collator should
- * be closed. Otherwise, a memory leak will result.
- * @param coll The UCollator to close.
- * @stable ICU 2.0
- */
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate void ucol_closeDelegate(IntPtr coll);
 
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_close" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern void ucol_close(IntPtr coll);
+		private static ucol_closeDelegate _ucol_close;
+
+		/// <summary>
+		/// Close a UCollator.
+		/// Once closed, a UCollator should not be used. Every open collator should
+		/// be closed. Otherwise, a memory leak will result.
+		/// </summary>
+		/// <param name="coll">The UCollator to close.</param>
+		public static void ucol_close(IntPtr coll)
+		{
+			if (_ucol_close == null)
+				_ucol_close = GetMethod<ucol_closeDelegate>(IcuI18NLibHandle, "ucol_close");
+			_ucol_close(coll);
+		}
 
 		/**
  * Compare two strings.
@@ -222,12 +363,27 @@ namespace Icu
  * @stable ICU 2.0
  */
 
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_strcoll" + ICU_VERSION_SUFFIX, CallingConvention = CallingConvention.Cdecl)]
-		public static extern CollationResult ucol_strcoll(RuleBasedCollator.SafeRuleBasedCollatorHandle collator,
-														  [MarshalAs(UnmanagedType.LPWStr)] string source,
-														  Int32 sourceLength,
-														  [MarshalAs(UnmanagedType.LPWStr)] string target,
-														  Int32 targetLength);
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate CollationResult ucol_strcollDelegate(
+			RuleBasedCollator.SafeRuleBasedCollatorHandle collator,
+			[MarshalAs(UnmanagedType.LPWStr)] string source,
+			Int32 sourceLength,
+			[MarshalAs(UnmanagedType.LPWStr)] string target,
+			Int32 targetLength);
+
+		private static ucol_strcollDelegate _ucol_strcoll;
+
+		public static CollationResult ucol_strcoll(
+			RuleBasedCollator.SafeRuleBasedCollatorHandle collator,
+			[MarshalAs(UnmanagedType.LPWStr)] string source,
+			Int32 sourceLength,
+			[MarshalAs(UnmanagedType.LPWStr)] string target,
+			Int32 targetLength)
+		{
+			if (_ucol_strcoll == null)
+				_ucol_strcoll = GetMethod<ucol_strcollDelegate>(IcuI18NLibHandle, "ucol_strcoll");
+			return _ucol_strcoll(collator, source, sourceLength, target, targetLength);
+		}
 
 		/**
  * Get the collation strength used in a UCollator.
@@ -240,8 +396,16 @@ namespace Icu
  */
 		/*
 
-[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getStrength"+ICU_VERSION_SUFFIX))]
-public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHandle collator);
+[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+private delegate CollationStrength ucol_getStrengthDelegate(SafeRuleBasedCollatorHandle collator);
+private static ucol_getStrengthDelegate _ucol_getStrength;
+
+public static CollationStrength ucol_getStrength(SafeRuleBasedCollatorHandle collator)
+{
+if (_ucol_getStrength == null)
+_ucol_getStrength = GetMethod<ucol_getStrengthDelegate>(IcuI18NLibHandle, "ucol_getStrength");
+return _ucol_getStrength(SafeRuleBasedCollatorHandle collator);
+};
 */
 
 		/**
@@ -254,9 +418,19 @@ public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHan
 * @stable ICU 2.0
 */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_setStrength"+ICU_VERSION_SUFFIX))]
-			public static extern void ucol_setStrength(SafeRuleBasedCollatorHandle collator,
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate void ucol_setStrengthDelegate(SafeRuleBasedCollatorHandle collator,
 													   CollationStrength strength);
+			private static ucol_setStrengthDelegate _ucol_setStrength;
+
+			public static void ucol_setStrength(SafeRuleBasedCollatorHandle collator,
+													   CollationStrength strength)
+			{
+			if (_ucol_setStrength == null)
+			_ucol_setStrength = GetMethod<ucol_setStrengthDelegate>(IcuI18NLibHandle, "ucol_setStrength");
+			return _ucol_setStrength(SafeRuleBasedCollatorHandle collator,
+													   CollationStrength strength);
+			};
 			*/
 
 		/**
@@ -272,12 +446,28 @@ public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHan
  * @stable ICU 2.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getDisplayName"+ICU_VERSION_SUFFIX)]
-			public static extern Int32 ucol_getDisplayName([MarshalAs(UnmanagedType.LPStr)] string objLoc,
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate Int32 ucol_getDisplayNameDelegate([MarshalAs(UnmanagedType.LPStr)] string objLoc,
 														   [MarshalAs(UnmanagedType.LPStr)] string dispLoc,
 														   [MarshalAs(UnmanagedType.LPWStr)] StringBuilder result,
 														   Int32 resultLength,
 														   out ErrorCode status);
+			private static ucol_getDisplayNameDelegate _ucol_getDisplayName;
+
+			public static Int32 ucol_getDisplayName([MarshalAs(UnmanagedType.LPStr)] string objLoc,
+														   [MarshalAs(UnmanagedType.LPStr)] string dispLoc,
+														   [MarshalAs(UnmanagedType.LPWStr)] StringBuilder result,
+														   Int32 resultLength,
+														   out ErrorCode status)
+			{
+			if (_ucol_getDisplayName == null)
+			_ucol_getDisplayName = GetMethod<ucol_getDisplayNameDelegate>(IcuI18NLibHandle, "ucol_getDisplayName");
+			return _ucol_getDisplayName([MarshalAs(UnmanagedType.LPStr)] string objLoc,
+														   [MarshalAs(UnmanagedType.LPStr)] string dispLoc,
+														   [MarshalAs(UnmanagedType.LPWStr)] StringBuilder result,
+														   Int32 resultLength,
+														   out ErrorCode status);
+			};
 			*/
 		/**
  * Get a locale for which collation rules are available.
@@ -289,7 +479,7 @@ public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHan
  * @stable ICU 2.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getAvailable"+ICU_VERSION_SUFFIX)]
+			[DllImport(IcuI18NLibHandle, EntryPoint = "ucol_getAvailable"+ICU_VERSION_SUFFIX)]
 			[return : MarshalAs(UnmanagedType.LPStr)]
 			public static extern string ucol_getAvailable(Int32 index);
 			*/
@@ -302,8 +492,17 @@ public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHan
  * @see ucol_getAvailable
  * @stable ICU 2.0
  */
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_countAvailable" + ICU_VERSION_SUFFIX, CallingConvention = CallingConvention.Cdecl)]
-		public static extern Int32 ucol_countAvailable();
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate Int32 ucol_countAvailableDelegate();
+
+		private static ucol_countAvailableDelegate _ucol_countAvailable;
+
+		public static Int32 ucol_countAvailable()
+		{
+			if (_ucol_countAvailable == null)
+				_ucol_countAvailable = GetMethod<ucol_countAvailableDelegate>(IcuI18NLibHandle, "ucol_countAvailable");
+			return _ucol_countAvailable();
+		}
 
 
 		/**
@@ -314,8 +513,17 @@ public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHan
  * responsible for closing the result.
  * @stable ICU 3.0
  */
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_openAvailableLocales" + ICU_VERSION_SUFFIX, CallingConvention = CallingConvention.Cdecl)]
-		public static extern RuleBasedCollator.SafeEnumeratorHandle ucol_openAvailableLocales(out ErrorCode status);
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate RuleBasedCollator.SafeEnumeratorHandle ucol_openAvailableLocalesDelegate(out ErrorCode status);
+
+		private static ucol_openAvailableLocalesDelegate _ucol_openAvailableLocales;
+
+		public static RuleBasedCollator.SafeEnumeratorHandle ucol_openAvailableLocales(out ErrorCode status)
+		{
+			if (_ucol_openAvailableLocales == null)
+				_ucol_openAvailableLocales = GetMethod<ucol_openAvailableLocalesDelegate>(IcuI18NLibHandle, "ucol_openAvailableLocales");
+			return _ucol_openAvailableLocales(out status);
+		}
 
 
 		/**
@@ -328,8 +536,16 @@ public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHan
  * @stable ICU 3.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getKeywords"+ICU_VERSION_SUFFIX))]
-			public static extern IntPtr ucol_getKeywords(out ErrorCode status);
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate IntPtr ucol_getKeywordsDelegate(out ErrorCode status);
+			private static ucol_getKeywordsDelegate _ucol_getKeywords;
+
+			public static IntPtr ucol_getKeywords(out ErrorCode status)
+			{
+			if (_ucol_getKeywords == null)
+			_ucol_getKeywords = GetMethod<ucol_getKeywordsDelegate>(IcuI18NLibHandle, "ucol_getKeywords");
+			return _ucol_getKeywords(out ErrorCode status);
+			};
 			*/
 
 
@@ -345,9 +561,19 @@ public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHan
  * @stable ICU 3.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getKeywordValues"+ICU_VERSION_SUFFIX))]
-			public static extern IntPtr ucol_getKeywordValues([MarshalAs(UnmanagedType.LPStr)] string keyword,
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate IntPtr ucol_getKeywordValuesDelegate([MarshalAs(UnmanagedType.LPStr)] string keyword,
 															  out ErrorCode status);
+			private static ucol_getKeywordValuesDelegate _ucol_getKeywordValues;
+
+			public static IntPtr ucol_getKeywordValues([MarshalAs(UnmanagedType.LPStr)] string keyword,
+															  out ErrorCode status)
+			{
+			if (_ucol_getKeywordValues == null)
+			_ucol_getKeywordValues = GetMethod<ucol_getKeywordValuesDelegate>(IcuI18NLibHandle, "ucol_getKeywordValues");
+			return _ucol_getKeywordValues([MarshalAs(UnmanagedType.LPStr)] string keyword,
+															  out ErrorCode status);
+			};
 			*/
 
 
@@ -383,14 +609,34 @@ public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHan
  * @stable ICU 3.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getFunctionalEquivalent" + ICU_VERSION_SUFFIX)]
-			public static extern Int32 ucol_getFunctionalEquivalent(
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate Int32 ucol_getFunctionalEquivalentDelegate(
 					[MarshalAs(UnmanagedType.LPStr)] StringBuilder result,
 					Int32 resultCapacity,
 					[MarshalAs(UnmanagedType.LPStr)] string keyword,
 					[MarshalAs(UnmanagedType.LPStr)] string locale,
 					[MarshalAs(UnmanagedType.I1)] out bool isAvailable,
 					out ErrorCode status);
+			private static ucol_getFunctionalEquivalentDelegate _ucol_getFunctionalEquivalent;
+
+			public static Int32 ucol_getFunctionalEquivalent(
+					[MarshalAs(UnmanagedType.LPStr)] StringBuilder result,
+					Int32 resultCapacity,
+					[MarshalAs(UnmanagedType.LPStr)] string keyword,
+					[MarshalAs(UnmanagedType.LPStr)] string locale,
+					[MarshalAs(UnmanagedType.I1)] out bool isAvailable,
+					out ErrorCode status)
+			{
+			if (_ucol_getFunctionalEquivalent == null)
+			_ucol_getFunctionalEquivalent = GetMethod<ucol_getFunctionalEquivalentDelegate>(IcuI18NLibHandle, "ucol_getFunctionalEquivalent");
+			return _ucol_getFunctionalEquivalent(
+					[MarshalAs(UnmanagedType.LPStr)] StringBuilder result,
+					Int32 resultCapacity,
+					[MarshalAs(UnmanagedType.LPStr)] string keyword,
+					[MarshalAs(UnmanagedType.LPStr)] string locale,
+					[MarshalAs(UnmanagedType.I1)] out bool isAvailable,
+					out ErrorCode status);
+			};
 			*/
 
 		/**
@@ -402,9 +648,19 @@ public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHan
  * @stable ICU 2.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getRules" + ICU_VERSION_SUFFIX)]
-			public static extern string ucol_getRules(SafeRuleBasedCollatorHandle collator,
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate string ucol_getRulesDelegate(SafeRuleBasedCollatorHandle collator,
 													  out Int32 length);
+			private static ucol_getRulesDelegate _ucol_getRules;
+
+			public static string ucol_getRules(SafeRuleBasedCollatorHandle collator,
+													  out Int32 length)
+			{
+			if (_ucol_getRules == null)
+			_ucol_getRules = GetMethod<ucol_getRulesDelegate>(IcuI18NLibHandle, "ucol_getRules");
+			return _ucol_getRules(SafeRuleBasedCollatorHandle collator,
+													  out Int32 length);
+			};
 			*/
 
 		/** Get the short definition string for a collator. This API harvests the collator's
@@ -428,13 +684,31 @@ public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHan
  *  @stable ICU 3.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getShortDefinitionString" + ICU_VERSION_SUFFIX)]
-			public static extern Int32 ucol_getShortDefinitionString(SafeRuleBasedCollatorHandle collator,
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate Int32 ucol_getShortDefinitionStringDelegate(SafeRuleBasedCollatorHandle collator,
 																	 [MarshalAs(UnmanagedType.LPStr)] string locale,
 																	 [In,Out][MarshalAs(UnmanagedType.LPStr)] StringBuilder
 																			 buffer,
 																	 Int32 capacity,
 																	 out ErrorCode status);
+			private static ucol_getShortDefinitionStringDelegate _ucol_getShortDefinitionString;
+
+			public static Int32 ucol_getShortDefinitionString(SafeRuleBasedCollatorHandle collator,
+																	 [MarshalAs(UnmanagedType.LPStr)] string locale,
+																	 [In,Out][MarshalAs(UnmanagedType.LPStr)] StringBuilder
+																			 buffer,
+																	 Int32 capacity,
+																	 out ErrorCode status)
+			{
+			if (_ucol_getShortDefinitionString == null)
+			_ucol_getShortDefinitionString = GetMethod<ucol_getShortDefinitionStringDelegate>(IcuI18NLibHandle, "ucol_getShortDefinitionString");
+			return _ucol_getShortDefinitionString(SafeRuleBasedCollatorHandle collator,
+																	 [MarshalAs(UnmanagedType.LPStr)] string locale,
+																	 [In,Out][MarshalAs(UnmanagedType.LPStr)] StringBuilder
+																			 buffer,
+																	 Int32 capacity,
+																	 out ErrorCode status);
+			};
 			*/
 		/** Verifies and normalizes short definition string.
  *  Normalized short definition string has all the option sorted by the argument name,
@@ -456,13 +730,31 @@ public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHan
  *  @stable ICU 3.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_normalizeShortDefinitionString" + ICU_VERSION_SUFFIX)]
-			public static extern Int32 ucol_normalizeShortDefinitionString(
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate Int32 ucol_normalizeShortDefinitionStringDelegate(
 					[MarshalAs(UnmanagedType.LPStr)] string source,
 					[MarshalAs(UnmanagedType.LPStr)] StringBuilder destination,
 					Int32 capacity,
 					ref ParseError parseError,
 					out ErrorCode status);
+			private static ucol_normalizeShortDefinitionStringDelegate _ucol_normalizeShortDefinitionString;
+
+			public static Int32 ucol_normalizeShortDefinitionString(
+					[MarshalAs(UnmanagedType.LPStr)] string source,
+					[MarshalAs(UnmanagedType.LPStr)] StringBuilder destination,
+					Int32 capacity,
+					ref ParseError parseError,
+					out ErrorCode status)
+			{
+			if (_ucol_normalizeShortDefinitionString == null)
+			_ucol_normalizeShortDefinitionString = GetMethod<ucol_normalizeShortDefinitionStringDelegate>(IcuI18NLibHandle, "ucol_normalizeShortDefinitionString");
+			return _ucol_normalizeShortDefinitionString(
+					[MarshalAs(UnmanagedType.LPStr)] string source,
+					[MarshalAs(UnmanagedType.LPStr)] StringBuilder destination,
+					Int32 capacity,
+					ref ParseError parseError,
+					out ErrorCode status);
+			};
 			*/
 		/**
  * Get a sort key for a string from a UCollator.
@@ -477,13 +769,27 @@ public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHan
  * @stable ICU 2.0
  */
 
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getSortKey" + ICU_VERSION_SUFFIX, CallingConvention = CallingConvention.Cdecl)]
-		public static extern Int32 ucol_getSortKey(RuleBasedCollator.SafeRuleBasedCollatorHandle collator,
-												   [MarshalAs(UnmanagedType.LPWStr)] string source,
-												   Int32 sourceLength,
-												   [Out, MarshalAs(UnmanagedType.LPArray)] byte[]
-												   result,
-												   Int32 resultLength);
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate Int32 ucol_getSortKeyDelegate(
+			RuleBasedCollator.SafeRuleBasedCollatorHandle collator,
+			[MarshalAs(UnmanagedType.LPWStr)] string source,
+			Int32 sourceLength,
+			[Out, MarshalAs(UnmanagedType.LPArray)] byte[] result,
+			Int32 resultLength);
+
+		private static ucol_getSortKeyDelegate _ucol_getSortKey;
+
+		public static Int32 ucol_getSortKey(
+			RuleBasedCollator.SafeRuleBasedCollatorHandle collator,
+			[MarshalAs(UnmanagedType.LPWStr)] string source,
+			Int32 sourceLength,
+			[Out, MarshalAs(UnmanagedType.LPArray)] byte[] result,
+			Int32 resultLength)
+		{
+			if (_ucol_getSortKey == null)
+				_ucol_getSortKey = GetMethod<ucol_getSortKeyDelegate>(IcuI18NLibHandle, "ucol_getSortKey");
+			return _ucol_getSortKey(collator, source, sourceLength, result, resultLength);
+		}
 
 		/** Gets the next count bytes of a sort key. Caller needs
  *  to preserve state array between calls and to provide
@@ -506,7 +812,7 @@ public static extern CollationStrength ucol_getStrength(SafeRuleBasedCollatorHan
  *  @stable ICU 2.6
  */
 		/*
-[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_nextSortKeyPart"+ICU_VERSION_SUFFIX))]
+[DllImport(IcuI18NLibHandle, EntryPoint = "ucol_nextSortKeyPart"+ICU_VERSION_SUFFIX)]
 		static public extern Int32
 ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 					 UCharIterator *iter,
@@ -564,7 +870,7 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  * @stable ICU 2.1
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getBound" + ICU_VERSION_SUFFIX)]
+			[DllImport(IcuI18NLibHandle, EntryPoint = "ucol_getBound" + ICU_VERSION_SUFFIX)]
 			public static extern Int32
 					ucol_getBound([MarshalAs(UnmanagedType.LPArray)] byte[] source,
 								  Int32 sourceLength,
@@ -583,10 +889,22 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  * @stable ICU 2.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getVersion" + ICU_VERSION_SUFFIX)]
-			public static extern void ucol_getVersion(
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate void ucol_getVersionDelegate(
 					SafeRuleBasedCollatorHandle collator,
 					out VersionInfo info);
+			private static ucol_getVersionDelegate _ucol_getVersion;
+
+			public static void ucol_getVersion(
+					SafeRuleBasedCollatorHandle collator,
+					out VersionInfo info)
+			{
+			if (_ucol_getVersion == null)
+			_ucol_getVersion = GetMethod<ucol_getVersionDelegate>(IcuI18NLibHandle, "ucol_getVersion");
+			return _ucol_getVersion(
+					SafeRuleBasedCollatorHandle collator,
+					out VersionInfo info);
+			};
 			*/
 		/**
  * Gets the UCA version information for a Collator. Version is the
@@ -596,10 +914,22 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  * @stable ICU 2.8
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getUCAVersion" + ICU_VERSION_SUFFIX)]
-			public static extern void ucol_getUCAVersion(
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate void ucol_getUCAVersionDelegate(
 					SafeRuleBasedCollatorHandle collator,
 					out VersionInfo info);
+			private static ucol_getUCAVersionDelegate _ucol_getUCAVersion;
+
+			public static void ucol_getUCAVersion(
+					SafeRuleBasedCollatorHandle collator,
+					out VersionInfo info)
+			{
+			if (_ucol_getUCAVersion == null)
+			_ucol_getUCAVersion = GetMethod<ucol_getUCAVersionDelegate>(IcuI18NLibHandle, "ucol_getUCAVersion");
+			return _ucol_getUCAVersion(
+					SafeRuleBasedCollatorHandle collator,
+					out VersionInfo info);
+			};
 			*/
 		/**
  * Merge two sort keys. The levels are merged with their corresponding counterparts
@@ -624,7 +954,7 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  * @stable ICU 2.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_mergeSortkeys" + ICU_VERSION_SUFFIX)]
+			[DllImport(IcuI18NLibHandle, EntryPoint = "ucol_mergeSortkeys" + ICU_VERSION_SUFFIX)]
 			public static extern Int32
 					ucol_mergeSortkeys([MarshalAs(UnmanagedType.LPArray)] byte[] src1,
 									   Int32 src1Length,
@@ -645,12 +975,25 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  * @stable ICU 2.0
  */
 
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_setAttribute" + ICU_VERSION_SUFFIX, CallingConvention = CallingConvention.Cdecl)]
-		public static extern void ucol_setAttribute(
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate void ucol_setAttributeDelegate(
 			RuleBasedCollator.SafeRuleBasedCollatorHandle collator,
 			CollationAttribute attr,
 			CollationAttributeValue value,
 			out ErrorCode status);
+
+		private static ucol_setAttributeDelegate _ucol_setAttribute;
+
+		public static void ucol_setAttribute(
+			RuleBasedCollator.SafeRuleBasedCollatorHandle collator,
+			CollationAttribute attr,
+			CollationAttributeValue value,
+			out ErrorCode status)
+		{
+			if (_ucol_setAttribute == null)
+				_ucol_setAttribute = GetMethod<ucol_setAttributeDelegate>(IcuI18NLibHandle, "ucol_setAttribute");
+			_ucol_setAttribute(collator, attr, value, out status);
+		}
 
 		/**
  * Universal attribute getter
@@ -664,11 +1007,23 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  * @stable ICU 2.0
  */
 
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getAttribute" + ICU_VERSION_SUFFIX, CallingConvention = CallingConvention.Cdecl)]
-		public static extern CollationAttributeValue ucol_getAttribute(
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate CollationAttributeValue ucol_getAttributeDelegate(
 			RuleBasedCollator.SafeRuleBasedCollatorHandle collator,
 			CollationAttribute attr,
 			out ErrorCode status);
+
+		private static ucol_getAttributeDelegate _ucol_getAttribute;
+
+		public static CollationAttributeValue ucol_getAttribute(
+			RuleBasedCollator.SafeRuleBasedCollatorHandle collator,
+			CollationAttribute attr,
+			out ErrorCode status)
+		{
+			if (_ucol_getAttribute == null)
+				_ucol_getAttribute = GetMethod<ucol_getAttributeDelegate>(IcuI18NLibHandle, "ucol_getAttribute");
+			return _ucol_getAttribute(collator, attr, out status);
+		}
 
 		/** Variable top
  * is a two byte primary value which causes all the codepoints with primary values that
@@ -690,12 +1045,28 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  * @stable ICU 2.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_setVariableTop" + ICU_VERSION_SUFFIX)]
-			public static extern UInt32 ucol_setVariableTop(
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate UInt32 ucol_setVariableTopDelegate(
 					SafeRuleBasedCollatorHandle collator,
 					[MarshalAs(UnmanagedType.LPWStr)] string varTop,
 					Int32 len,
 					out ErrorCode status);
+			private static ucol_setVariableTopDelegate _ucol_setVariableTop;
+
+			public static UInt32 ucol_setVariableTop(
+					SafeRuleBasedCollatorHandle collator,
+					[MarshalAs(UnmanagedType.LPWStr)] string varTop,
+					Int32 len,
+					out ErrorCode status)
+			{
+			if (_ucol_setVariableTop == null)
+			_ucol_setVariableTop = GetMethod<ucol_setVariableTopDelegate>(IcuI18NLibHandle, "ucol_setVariableTop");
+			return _ucol_setVariableTop(
+					SafeRuleBasedCollatorHandle collator,
+					[MarshalAs(UnmanagedType.LPWStr)] string varTop,
+					Int32 len,
+					out ErrorCode status);
+			};
 			*/
 		/**
  * Gets the variable top value of a Collator.
@@ -709,10 +1080,22 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  * @stable ICU 2.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getVariableTop" + ICU_VERSION_SUFFIX)]
-			public static extern UInt32 ucol_getVariableTop(
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate UInt32 ucol_getVariableTopDelegate(
 					SafeRuleBasedCollatorHandle collator,
 					out ErrorCode status);
+			private static ucol_getVariableTopDelegate _ucol_getVariableTop;
+
+			public static UInt32 ucol_getVariableTop(
+					SafeRuleBasedCollatorHandle collator,
+					out ErrorCode status)
+			{
+			if (_ucol_getVariableTop == null)
+			_ucol_getVariableTop = GetMethod<ucol_getVariableTopDelegate>(IcuI18NLibHandle, "ucol_getVariableTop");
+			return _ucol_getVariableTop(
+					SafeRuleBasedCollatorHandle collator,
+					out ErrorCode status);
+			};
 			*/
 		/**
  * Sets the variable top to a collation element value supplied. Variable top is
@@ -726,11 +1109,25 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  * @stable ICU 2.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_restoreVariableTop" + ICU_VERSION_SUFFIX)]
-			public static extern void ucol_restoreVariableTop(
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate void ucol_restoreVariableTopDelegate(
 					SafeRuleBasedCollatorHandle collator,
 					UInt32 varTop,
 					out ErrorCode status);
+			private static ucol_restoreVariableTopDelegate _ucol_restoreVariableTop;
+
+			public static void ucol_restoreVariableTop(
+					SafeRuleBasedCollatorHandle collator,
+					UInt32 varTop,
+					out ErrorCode status)
+			{
+			if (_ucol_restoreVariableTop == null)
+			_ucol_restoreVariableTop = GetMethod<ucol_restoreVariableTopDelegate>(IcuI18NLibHandle, "ucol_restoreVariableTop");
+			return _ucol_restoreVariableTop(
+					SafeRuleBasedCollatorHandle collator,
+					UInt32 varTop,
+					out ErrorCode status);
+			};
 			*/
 		/**
  * Thread safe cloning operation. The result is a clone of a given collator.
@@ -755,12 +1152,25 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  * @stable ICU 2.0
  */
 
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_safeClone" + ICU_VERSION_SUFFIX, CallingConvention = CallingConvention.Cdecl)]
-		public static extern RuleBasedCollator.SafeRuleBasedCollatorHandle ucol_safeClone(
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate RuleBasedCollator.SafeRuleBasedCollatorHandle ucol_safeCloneDelegate(
 			RuleBasedCollator.SafeRuleBasedCollatorHandle collator,
 			IntPtr stackBuffer,
 			ref Int32 pBufferSize,
 			out ErrorCode status);
+
+		private static ucol_safeCloneDelegate _ucol_safeClone;
+
+		public static RuleBasedCollator.SafeRuleBasedCollatorHandle ucol_safeClone(
+			RuleBasedCollator.SafeRuleBasedCollatorHandle collator,
+			IntPtr stackBuffer,
+			ref Int32 pBufferSize,
+			out ErrorCode status)
+		{
+			if (_ucol_safeClone == null)
+				_ucol_safeClone = GetMethod<ucol_safeCloneDelegate>(IcuI18NLibHandle, "ucol_safeClone");
+			return _ucol_safeClone(collator, stackBuffer, ref pBufferSize, out status);
+		}
 
 		/**
  * Returns current rules. Delta defines whether full rules are returned or just the tailoring.
@@ -774,12 +1184,28 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  * @stable ICU 2.0
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getRulesEx" + ICU_VERSION_SUFFIX)]
-			public static extern Int32 ucol_getRulesEx(
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			private delegate Int32 ucol_getRulesExDelegate(
 					SafeRuleBasedCollatorHandle collator,
 					CollationRuleOption delta,
 					[MarshalAs(UnmanagedType.LPWStr)] StringBuilder buffer,
 					Int32 bufferLen);
+			private static ucol_getRulesExDelegate _ucol_getRulesEx;
+
+			public static Int32 ucol_getRulesEx(
+					SafeRuleBasedCollatorHandle collator,
+					CollationRuleOption delta,
+					[MarshalAs(UnmanagedType.LPWStr)] StringBuilder buffer,
+					Int32 bufferLen)
+			{
+			if (_ucol_getRulesEx == null)
+			_ucol_getRulesEx = GetMethod<ucol_getRulesExDelegate>(IcuI18NLibHandle, "ucol_getRulesEx");
+			return _ucol_getRulesEx(
+					SafeRuleBasedCollatorHandle collator,
+					CollationRuleOption delta,
+					[MarshalAs(UnmanagedType.LPWStr)] StringBuilder buffer,
+					Int32 bufferLen);
+			};
 			*/
 		/**
  * gets the locale name of the collator. If the collator
@@ -801,12 +1227,24 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		// creates a copy of the string and tries to de-allocate the C memory used by the
 		// char*. Using IntPtr will not create a copy of any object and therefore will not
 		// try to de-allocate memory. De-allocating memory from a string literal is not a
-		// good Idea. To call the function use Marshal.PtrToString*(ucol_getLocaleByType(...));
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getLocaleByType" + ICU_VERSION_SUFFIX,
-			CallingConvention = CallingConvention.Cdecl)]
-		public static extern IntPtr
-			ucol_getLocaleByType(RuleBasedCollator.SafeRuleBasedCollatorHandle collator, LocaleType type,
-								 out ErrorCode status);
+		// good Idea. To call the function use Marshal.PtrToString*(ucol_getLocaleByType(...);
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate IntPtr ucol_getLocaleByTypeDelegate(
+			RuleBasedCollator.SafeRuleBasedCollatorHandle collator,
+			LocaleType type,
+			out ErrorCode status);
+
+		private static ucol_getLocaleByTypeDelegate _ucol_getLocaleByType;
+
+		public static IntPtr ucol_getLocaleByType(
+			RuleBasedCollator.SafeRuleBasedCollatorHandle collator, 
+			LocaleType type,
+			out ErrorCode status)
+		{
+			if (_ucol_getLocaleByType == null)
+				_ucol_getLocaleByType = GetMethod<ucol_getLocaleByTypeDelegate>(IcuI18NLibHandle, "ucol_getLocaleByType");
+			return _ucol_getLocaleByType(collator, type, out status);
+		}
 
 		/**
  * Get an Unicode set that contains all the characters and sequences tailored in
@@ -819,7 +1257,7 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  * @stable ICU 2.4
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getTailoredSet" + ICU_VERSION_SUFFIX)]
+			[DllImport(IcuI18NLibHandle, EntryPoint = "ucol_getTailoredSet" + ICU_VERSION_SUFFIX)]
 			public static extern IntPtr
 					ucol_getTailoredSet(SafeRuleBasedCollatorHandle collator, out ErrorCode status);
 			*/
@@ -836,7 +1274,7 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  *  @stable ICU 3.2
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_cloneBinary" + ICU_VERSION_SUFFIX)]
+			[DllImport(IcuI18NLibHandle, EntryPoint = "ucol_cloneBinary" + ICU_VERSION_SUFFIX)]
 			public static extern Int32
 					ucol_cloneBinary(SafeRuleBasedCollatorHandle collator,
 									 [MarshalAs(UnmanagedType.U1)] out int buffer, Int32 capacity,
@@ -860,28 +1298,67 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
  *  @stable ICU 3.2
  */
 		/*
-			[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_openBinary" + ICU_VERSION_SUFFIX)]
+			[DllImport(IcuI18NLibHandle, EntryPoint = "ucol_openBinary" + ICU_VERSION_SUFFIX)]
 			public static extern SafeRuleBasedCollatorHandle
 					ucol_openBinary(byte[] bin, Int32 length,
 									SafeRuleBasedCollatorHandle baseCollator,
 									out ErrorCode status);
 			*/
 
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getRulesEx" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern int ucol_getRulesEx(RuleBasedCollator.SafeRuleBasedCollatorHandle coll, UColRuleOption delta, IntPtr buffer, int bufferLen);
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int ucol_getRulesExDelegate(
+			RuleBasedCollator.SafeRuleBasedCollatorHandle coll,
+			UColRuleOption delta,
+			IntPtr buffer,
+			int bufferLen);
+
+		private static ucol_getRulesExDelegate _ucol_getRulesEx;
+
+		public static int ucol_getRulesEx(
+			RuleBasedCollator.SafeRuleBasedCollatorHandle coll,
+			UColRuleOption delta,
+			IntPtr buffer,
+			int bufferLen)
+		{
+			if (_ucol_getRulesEx == null)
+				_ucol_getRulesEx = GetMethod<ucol_getRulesExDelegate>(IcuI18NLibHandle, "ucol_getRulesEx");
+			return _ucol_getRulesEx(coll, delta, buffer, bufferLen);
+		}
+
 		/// <summary>Test the rules to see if they are valid.</summary>
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_openRules" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern IntPtr ucol_openRules(string rules, int rulesLength, UColAttributeValue normalizationMode,
-													UColAttributeValue strength, out ParseError parseError, out ErrorCode status);
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate IntPtr ucol_openRulesDelegate2(string rules, int rulesLength,
+			UColAttributeValue normalizationMode, UColAttributeValue strength,
+			out ParseError parseError, out ErrorCode status);
 
-		[DllImport(ICU_I18N_LIB, EntryPoint = "ucol_getBound" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern int ucol_getBound(byte[] source, int sourceLength, UColBoundMode boundType, int noOfLevels,
-												byte[] result, int resultLength, out ErrorCode status);
+		private static ucol_openRulesDelegate2 _ucol_openRules2;
 
-		#endregion Unicode collator
+		public static IntPtr ucol_openRules(string rules, int rulesLength,
+			UColAttributeValue normalizationMode, UColAttributeValue strength,
+			out ParseError parseError, out ErrorCode status)
+		{
+			if (_ucol_openRules2 == null)
+				_ucol_openRules2 = GetMethod<ucol_openRulesDelegate2>(IcuI18NLibHandle, "ucol_openRules");
+			return _ucol_openRules2(rules, rulesLength, normalizationMode, strength, out parseError, out status);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int ucol_getBoundDelegate(byte[] source, int sourceLength,
+			UColBoundMode boundType, int noOfLevels, byte[] result, int resultLength,
+			out ErrorCode status);
+
+		private static ucol_getBoundDelegate _ucol_getBound;
+
+		public static int ucol_getBound(byte[] source, int sourceLength,
+			UColBoundMode boundType, int noOfLevels, byte[] result, int resultLength,
+			out ErrorCode status)
+		{
+			if (_ucol_getBound == null)
+				_ucol_getBound = GetMethod<ucol_getBoundDelegate>(IcuI18NLibHandle, "ucol_getBound");
+			return _ucol_getBound(source, sourceLength, boundType, noOfLevels, result, resultLength, out status);
+		}
+
+		#endregion // Unicode collator
 
 		/*
 			public enum CollationRuleOption
@@ -896,15 +1373,16 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 				FullRules
 			}
 		*/
-		public enum  LocaleType {
+		public enum  LocaleType
+		{
 			/// <summary>
 			/// This is locale the data actually comes from
 			/// </summary>
-			ActualLocale    = 0,
+			ActualLocale = 0,
 			/// <summary>
 			/// This is the most specific locale supported by ICU
 			/// </summary>
-			ValidLocale    = 1,
+			ValidLocale = 1,
 		}
 
 		public enum CollationAttributeValue
@@ -917,10 +1395,8 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 			Quaternary = 3, //Quaternary collation strength
 			Identical = 15, //Identical collation strength
 
-			Off = 16,
-			//Turn the feature off - works for FrenchCollation, CaseLevel, HiraganaQuaternaryMode, DecompositionMode
-			On = 17,
-			//Turn the feature on - works for FrenchCollation, CaseLevel, HiraganaQuaternaryMode, DecompositionMode
+			Off = 16, //Turn the feature off - works for FrenchCollation, CaseLevel, HiraganaQuaternaryMode, DecompositionMode
+			On = 17, //Turn the feature on - works for FrenchCollation, CaseLevel, HiraganaQuaternaryMode, DecompositionMode
 
 			Shifted = 20, // Valid for AlternateHandling. Alternate handling will be shifted
 			NonIgnorable = 21, // Valid for AlternateHandling. Alternate handling will be non-ignorable
@@ -950,47 +1426,110 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 			Less = -1
 		}
 
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate void u_InitDelegate(out ErrorCode errorCode);
+
+		private static u_InitDelegate _u_Init;
+
 		/// <summary>get the name of an ICU code point</summary>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_init" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern void u_Init(out ErrorCode errorCode);
+		public static void u_Init(out ErrorCode errorCode)
+		{
+			if (_u_Init == null)
+				_u_Init = GetMethod<u_InitDelegate>(IcuCommonLibHandle, "u_Init");
+			_u_Init(out errorCode);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate void u_CleanupDelegate();
+
+		private static u_CleanupDelegate _u_Cleanup;
 
 		/// <summary>Clean up the ICU files that could be locked</summary>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_cleanup" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern void u_Cleanup();
+		public static void u_Cleanup()
+		{
+			if (_u_Cleanup == null)
+				_u_Cleanup = GetMethod<u_CleanupDelegate>(IcuCommonLibHandle, "u_Cleanup");
+			_u_Cleanup();
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate IntPtr u_GetDataDirectoryDelegate();
+
+		private static u_GetDataDirectoryDelegate _u_GetDataDirectory;
 
 		/// <summary>Return the ICU data directory</summary>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_getDataDirectory" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern IntPtr u_GetDataDirectory();
+		public static IntPtr u_GetDataDirectory()
+		{
+			if (_u_GetDataDirectory == null)
+				_u_GetDataDirectory = GetMethod<u_GetDataDirectoryDelegate>(IcuCommonLibHandle, "u_GetDataDirectory");
+			return _u_GetDataDirectory();
+		}
 
-		/// <summary>Set the ICU data directory</summary>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_setDataDirectory" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern void u_SetDataDirectory(
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate void u_SetDataDirectoryDelegate(
 			[MarshalAs(UnmanagedType.LPStr)]string directory);
 
-		/// <summary>get the name of an ICU code point</summary>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_charName" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern int u_CharName(
+		private static u_SetDataDirectoryDelegate _u_SetDataDirectory;
+
+		/// <summary>Set the ICU data directory</summary>
+		public static void u_SetDataDirectory(
+			[MarshalAs(UnmanagedType.LPStr)]string directory)
+		{
+			if (_u_SetDataDirectory == null)
+				_u_SetDataDirectory = GetMethod<u_SetDataDirectoryDelegate>(IcuCommonLibHandle, "u_SetDataDirectory");
+			_u_SetDataDirectory(directory);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int u_charNameDelegate(
 			int code,
 			Character.UCharNameChoice nameChoice,
 			IntPtr buffer,
 			int bufferLength,
 			out ErrorCode errorCode);
 
+		private static u_charNameDelegate _u_charName;
+
+		/// <summary>get the name of an ICU code point</summary>
+		public static int u_charName(
+			int code,
+			Character.UCharNameChoice nameChoice,
+			IntPtr buffer,
+			int bufferLength,
+			out ErrorCode errorCode)
+		{
+			if (_u_charName == null)
+				_u_charName = GetMethod<u_charNameDelegate>(IcuCommonLibHandle, "u_charName");
+			return _u_charName(code, nameChoice, buffer, bufferLength, out errorCode);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int u_digitDelegate(
+			int characterCode,
+			byte radix);
+
+		private static u_digitDelegate _u_digit;
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// get the numeric value for the Unicode digit
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_digit" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern int u_digit(
+		public static int u_digit(
 			int characterCode,
-			byte radix);
+			byte radix)
+		{
+			if (_u_digit == null)
+				_u_digit = GetMethod<u_digitDelegate>(IcuCommonLibHandle, "u_digit");
+			return _u_digit(characterCode, radix);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int u_getIntPropertyValueDelegate(
+			int characterCode,
+			Character.UProperty choice);
+
+		private static u_getIntPropertyValueDelegate _u_getIntPropertyValue;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1004,15 +1543,31 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// enumeration that doesn't match the enumeration in FwKernel: LgGeneralCharCategory
 		/// </remarks>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_getIntPropertyValue" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern int u_getIntPropertyValue(
+		public static int u_getIntPropertyValue(
 			int characterCode,
-			Character.UProperty choice);
+			Character.UProperty choice)
+		{
+			if (_u_getIntPropertyValue == null)
+				_u_getIntPropertyValue = GetMethod<u_getIntPropertyValueDelegate>(IcuCommonLibHandle, "u_getIntPropertyValue");
+			return _u_getIntPropertyValue(characterCode, choice);
+		}
 
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_getUnicodeVersion" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern void u_getUnicodeVersion(out VersionInfo versionArray);
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate void u_getUnicodeVersionDelegate(out VersionInfo versionArray);
+
+		private static u_getUnicodeVersionDelegate _u_getUnicodeVersion;
+
+		public static void u_getUnicodeVersion(out VersionInfo versionArray)
+		{
+			if (_u_getUnicodeVersion == null)
+				_u_getUnicodeVersion = GetMethod<u_getUnicodeVersionDelegate>(IcuCommonLibHandle, "u_getUnicodeVersion");
+			_u_getUnicodeVersion(out versionArray);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate void u_getVersionDelegate(out VersionInfo versionArray);
+
+		private static u_getVersionDelegate _u_getVersion;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1020,18 +1575,35 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// </summary>
 		/// <param name="versionArray">Stores the version information for ICU.</param>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_getVersion" + ICU_VERSION_SUFFIX,
-			CallingConvention = CallingConvention.Cdecl)]
-		public static extern void u_getVersion(out VersionInfo versionArray);
+		public static void u_getVersion(out VersionInfo versionArray)
+		{
+			if (_u_getVersion == null)
+				_u_getVersion = GetMethod<u_getVersionDelegate>(IcuCommonLibHandle, "u_getVersion");
+			_u_getVersion(out versionArray);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int u_charTypeDelegate(int characterCode);
+
+		private static u_charTypeDelegate _u_charType;
 
 		/// <summary>
 		/// Get the general character type.
 		/// </summary>
 		/// <param name="characterCode"></param>
 		/// <returns></returns>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_charType" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern int u_charType(int characterCode);
+		public static int u_charType(int characterCode)
+		{
+			if (_u_charType == null)
+				_u_charType = GetMethod<u_charTypeDelegate>(IcuCommonLibHandle, "u_charType");
+			return _u_charType(characterCode);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate double u_getNumericValueDelegate(
+			int characterCode);
+
+		private static u_getNumericValueDelegate _u_getNumericValue;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1053,10 +1625,21 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		///<param name="characterCode">Code point to get the numeric value for</param>
 		///<returns>Numeric value of c, or U_NO_NUMERIC_VALUE if none is defined.</returns>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_getNumericValue" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern double u_getNumericValue(
-			int characterCode);
+		public static double u_getNumericValue(
+			int characterCode)
+		{
+			if (_u_getNumericValue == null)
+				_u_getNumericValue = GetMethod<u_getNumericValueDelegate>(IcuCommonLibHandle, "u_getNumericValue");
+			return _u_getNumericValue(characterCode);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		// Required because ICU returns a one-byte boolean. Without this C# assumes 4, and picks up 3 more random bytes,
+		// which are usually zero, especially in debug builds...but one day we will be sorry.
+		[return: MarshalAs(UnmanagedType.I1)]
+		private delegate bool u_ispunctDelegate(int characterCode);
+
+		private static u_ispunctDelegate _u_ispunct;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1064,13 +1647,21 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// </summary>
 		/// <param name="characterCode">the code point to be tested</param>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_ispunct" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
+		public static bool u_ispunct(
+			int characterCode)
+		{
+			if (_u_ispunct == null)
+				_u_ispunct = GetMethod<u_ispunctDelegate>(IcuCommonLibHandle, "u_ispunct");
+			return _u_ispunct(characterCode);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
 		// Required because ICU returns a one-byte boolean. Without this C# assumes 4, and picks up 3 more random bytes,
 		// which are usually zero, especially in debug builds...but one day we will be sorry.
 		[return: MarshalAs(UnmanagedType.I1)]
-		public static extern bool u_ispunct(
-			int characterCode);
+		private delegate bool u_isMirroredDelegate(int characterCode);
+
+		private static u_isMirroredDelegate _u_isMirrored;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1091,13 +1682,21 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// <param name="characterCode">the code point to be tested</param>
 		/// <returns><c>true</c> if the character has the Bidi_Mirrored property</returns>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_isMirrored" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
+		public static bool u_isMirrored(
+			int characterCode)
+		{
+			if (_u_isMirrored == null)
+				_u_isMirrored = GetMethod<u_isMirroredDelegate>(IcuCommonLibHandle, "u_isMirrored");
+			return _u_isMirrored(characterCode);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
 		// Required because ICU returns a one-byte boolean. Without this C# assumes 4, and picks up 3 more random bytes,
 		// which are usually zero, especially in debug builds...but one day we will be sorry.
 		[return: MarshalAs(UnmanagedType.I1)]
-		public static extern bool u_isMirrored(
-			int characterCode);
+		private delegate bool u_iscntrlDelegate(int characterCode);
+
+		private static u_iscntrlDelegate _u_iscntrl;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1113,13 +1712,21 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// </summary>
 		/// <param name="characterCode">the code point to be tested</param>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_iscntrl" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
+		public static bool u_iscntrl(
+			int characterCode)
+		{
+			if (_u_iscntrl == null)
+				_u_iscntrl = GetMethod<u_iscntrlDelegate>(IcuCommonLibHandle, "u_iscntrl");
+			return _u_iscntrl(characterCode);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
 		// Required because ICU returns a one-byte boolean. Without this C# assumes 4, and picks up 3 more random bytes,
 		// which are usually zero, especially in debug builds...but one day we will be sorry.
 		[return: MarshalAs(UnmanagedType.I1)]
-		public static extern bool u_iscntrl(
-			int characterCode);
+		private delegate bool u_isspaceDelegate(int characterCode);
+
+		private static u_isspaceDelegate _u_isspace;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1138,44 +1745,84 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		///	</remarks>
 		/// <param name="characterCode">the code point to be tested</param>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_isspace" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		// Required because ICU returns a one-byte boolean. Without this C# assumes 4, and picks up 3 more random bytes,
-		// which are usually zero, especially in debug builds...but one day we will be sorry.
-		[return: MarshalAs(UnmanagedType.I1)]
-		public static extern bool u_isspace(
-			int characterCode);
+		public static bool u_isspace(
+			int characterCode)
+		{
+			if (_u_isspace == null)
+				_u_isspace = GetMethod<u_isspaceDelegate>(IcuCommonLibHandle, "u_isspace");
+			return _u_isspace(characterCode);
+		}
 
 		#region LCID
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int uloc_getLCIDDelegate([MarshalAs(UnmanagedType.LPStr)]string localeID);
+
+		private static uloc_getLCIDDelegate _uloc_getLCID;
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>Get the ICU LCID for a locale</summary>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getLCID" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_getLCID([MarshalAs(UnmanagedType.LPStr)]string localeID);
+		public static int uloc_getLCID([MarshalAs(UnmanagedType.LPStr)]string localeID)
+		{
+			if (_uloc_getLCID == null)
+				_uloc_getLCID = GetMethod<uloc_getLCIDDelegate>(IcuCommonLibHandle, "uloc_getLCID");
+			return _uloc_getLCID(localeID);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int uloc_getLocaleForLCIDDelegate(int lcid,IntPtr locale,int localeCapacity,out ErrorCode err);
+
+		private static uloc_getLocaleForLCIDDelegate _uloc_getLocaleForLCID;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>Gets the ICU locale ID for the specified Win32 LCID value. </summary>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getLocaleForLCID" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_getLocaleForLCID(int lcid, IntPtr locale, int localeCapacity, out ErrorCode err);
+		public static int uloc_getLocaleForLCID(int lcid, IntPtr locale, int localeCapacity, out ErrorCode err)
+		{
+			if (_uloc_getLocaleForLCID == null)
+				_uloc_getLocaleForLCID = GetMethod<uloc_getLocaleForLCIDDelegate>(IcuCommonLibHandle, "uloc_getLocaleForLCID");
+			return _uloc_getLocaleForLCID(lcid, locale, localeCapacity, out err);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate IntPtr uloc_getISO3CountryDelegate(
+			[MarshalAs(UnmanagedType.LPStr)]string locale);
+
+		private static uloc_getISO3CountryDelegate _uloc_getISO3Country;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>Return the ISO 3 char value, if it exists</summary>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getISO3Country" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern IntPtr uloc_getISO3Country(
+		public static IntPtr uloc_getISO3Country(
+			[MarshalAs(UnmanagedType.LPStr)]string locale)
+		{
+			if (_uloc_getISO3Country == null)
+				_uloc_getISO3Country = GetMethod<uloc_getISO3CountryDelegate>(IcuCommonLibHandle, "uloc_getISO3Country");
+			return _uloc_getISO3Country(locale);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate IntPtr uloc_getISO3LanguageDelegate(
 			[MarshalAs(UnmanagedType.LPStr)]string locale);
+
+		private static uloc_getISO3LanguageDelegate _uloc_getISO3Language;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>Return the ISO 3 char value, if it exists</summary>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getISO3Language" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern IntPtr uloc_getISO3Language(
-			[MarshalAs(UnmanagedType.LPStr)]string locale);
+		public static IntPtr uloc_getISO3Language(
+			[MarshalAs(UnmanagedType.LPStr)]string locale)
+		{
+			if (_uloc_getISO3Language == null)
+				_uloc_getISO3Language = GetMethod<uloc_getISO3LanguageDelegate>(IcuCommonLibHandle, "uloc_getISO3Language");
+			return _uloc_getISO3Language(locale);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate int uloc_countAvailableDelegate();
+
+		private static uloc_countAvailableDelegate _uloc_countAvailable;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1183,9 +1830,17 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// </summary>
 		/// <returns>the size of the locale list </returns>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_countAvailable" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_countAvailable();
+		public static int uloc_countAvailable()
+		{
+			if (_uloc_countAvailable == null)
+				_uloc_countAvailable = GetMethod<uloc_countAvailableDelegate>(IcuCommonLibHandle, "uloc_countAvailable");
+			return _uloc_countAvailable();
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate IntPtr uloc_getAvailableDelegate(int n);
+
+		private static uloc_getAvailableDelegate _uloc_getAvailable;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1197,9 +1852,18 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// <param name="n">n  the specific locale name index of the available locale list</param>
 		/// <returns>a specified locale name of all available locales</returns>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getAvailable" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern IntPtr uloc_getAvailable(int n);
+		public static IntPtr uloc_getAvailable(int n)
+		{
+			if (_uloc_getAvailable == null)
+				_uloc_getAvailable = GetMethod<uloc_getAvailableDelegate>(IcuCommonLibHandle, "uloc_getAvailable");
+			return _uloc_getAvailable(n);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate int uloc_getLanguageDelegate(string localeID, IntPtr language,
+			int languageCapacity, out ErrorCode err);
+
+		private static uloc_getLanguageDelegate _uloc_getLanguage;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1213,10 +1877,19 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// <returns>the actual buffer size needed for the language code. If it's greater
 		/// than languageCapacity, the returned language code will be truncated</returns>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getLanguage" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_getLanguage(string localeID, IntPtr language,
-												   int languageCapacity, out ErrorCode err);
+		public static int uloc_getLanguage(string localeID, IntPtr language,
+			int languageCapacity, out ErrorCode err)
+		{
+			if (_uloc_getLanguage == null)
+				_uloc_getLanguage = GetMethod<uloc_getLanguageDelegate>(IcuCommonLibHandle, "uloc_getLanguage");
+			return _uloc_getLanguage(localeID, language, languageCapacity, out err);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate int uloc_getScriptDelegate(string localeID, IntPtr script,
+			int scriptCapacity, out ErrorCode err);
+
+		private static uloc_getScriptDelegate _uloc_getScript;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1230,10 +1903,19 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// <returns>the actual buffer size needed for the script code. If it's greater
 		/// than scriptCapacity, the returned script code will be truncated</returns>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getScript" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_getScript(string localeID, IntPtr script,
-												 int scriptCapacity, out ErrorCode err);
+		public static int uloc_getScript(string localeID, IntPtr script,
+			int scriptCapacity, out ErrorCode err)
+		{
+			if (_uloc_getScript == null)
+				_uloc_getScript = GetMethod<uloc_getScriptDelegate>(IcuCommonLibHandle, "uloc_getScript");
+			return _uloc_getScript(localeID, script, scriptCapacity, out err);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate int uloc_getCountryDelegate(string localeID, IntPtr country,
+			int countryCapacity,out ErrorCode err);
+
+		private static uloc_getCountryDelegate _uloc_getCountry;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1247,10 +1929,19 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// <returns>the actual buffer size needed for the country code. If it's greater
 		/// than countryCapacity, the returned country code will be truncated</returns>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getCountry" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_getCountry(string localeID, IntPtr country,
-												  int countryCapacity, out ErrorCode err);
+		public static int uloc_getCountry(string localeID, IntPtr country,
+			int countryCapacity,out ErrorCode err)
+		{
+			if (_uloc_getCountry == null)
+				_uloc_getCountry = GetMethod<uloc_getCountryDelegate>(IcuCommonLibHandle, "uloc_getCountry");
+			return _uloc_getCountry(localeID, country, countryCapacity, out err);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate int uloc_getVariantDelegate(string localeID, IntPtr variant,
+			int variantCapacity, out ErrorCode err);
+
+		private static uloc_getVariantDelegate _uloc_getVariant;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1264,10 +1955,19 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// <returns>the actual buffer size needed for the variant code. If it's greater
 		/// than variantCapacity, the returned variant code will be truncated</returns>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getVariant" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_getVariant(string localeID, IntPtr variant,
-												  int variantCapacity, out ErrorCode err);
+		public static int uloc_getVariant(string localeID, IntPtr variant,
+			int variantCapacity, out ErrorCode err)
+		{
+			if (_uloc_getVariant == null)
+				_uloc_getVariant = GetMethod<uloc_getVariantDelegate>(IcuCommonLibHandle, "uloc_getVariant");
+			return _uloc_getVariant(localeID, variant, variantCapacity, out err);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate int uloc_getDisplayNameDelegate(string localeID, string inLocaleID,
+			IntPtr result, int maxResultSize, out ErrorCode err);
+
+		private static uloc_getDisplayNameDelegate _uloc_getDisplayName;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -1285,90 +1985,212 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// <returns>the actual buffer size needed for the displayable name. If it's greater
 		/// than variantCapacity, the returned displayable name will be truncated.</returns>
 		/// ------------------------------------------------------------------------------------
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getDisplayName" + ICU_VERSION_SUFFIX,
-			CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_getDisplayName(string localeID, string inLocaleID,
+		public static int uloc_getDisplayName(string localeID, string inLocaleID,
+			IntPtr result, int maxResultSize, out ErrorCode err)
+		{
+			if (_uloc_getDisplayName == null)
+				_uloc_getDisplayName = GetMethod<uloc_getDisplayNameDelegate>(IcuCommonLibHandle, "uloc_getDisplayName");
+			return _uloc_getDisplayName(localeID, inLocaleID, result, maxResultSize, out err);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate int uloc_getDisplayLanguageDelegate(string localeID, string displayLocaleID,
 			IntPtr result, int maxResultSize, out ErrorCode err);
 
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getDisplayLanguage" + ICU_VERSION_SUFFIX,
-			CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_getDisplayLanguage(string localeID, string displayLocaleID,
+		private static uloc_getDisplayLanguageDelegate _uloc_getDisplayLanguage;
+
+		public static int uloc_getDisplayLanguage(string localeID, string displayLocaleID,
+			IntPtr result, int maxResultSize, out ErrorCode err)
+		{
+			if (_uloc_getDisplayLanguage == null)
+				_uloc_getDisplayLanguage = GetMethod<uloc_getDisplayLanguageDelegate>(IcuCommonLibHandle, "uloc_getDisplayLanguage");
+			return _uloc_getDisplayLanguage(localeID, displayLocaleID, result, maxResultSize, out err);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate int uloc_getDisplayScriptDelegate(string localeID, string displayLocaleID,
 			IntPtr result, int maxResultSize, out ErrorCode err);
 
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getDisplayScript" + ICU_VERSION_SUFFIX,
-			CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_getDisplayScript(string localeID, string displayLocaleID,
+		private static uloc_getDisplayScriptDelegate _uloc_getDisplayScript;
+
+		public static int uloc_getDisplayScript(string localeID, string displayLocaleID,
+			IntPtr result, int maxResultSize, out ErrorCode err)
+		{
+			if (_uloc_getDisplayScript == null)
+				_uloc_getDisplayScript = GetMethod<uloc_getDisplayScriptDelegate>(IcuCommonLibHandle, "uloc_getDisplayScript");
+			return _uloc_getDisplayScript(localeID, displayLocaleID, result, maxResultSize, out err);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate int uloc_getDisplayCountryDelegate(string localeID, string displayLocaleID,
 			IntPtr result, int maxResultSize, out ErrorCode err);
 
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getDisplayCountry" + ICU_VERSION_SUFFIX,
-			CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_getDisplayCountry(string localeID, string displayLocaleID,
+		private static uloc_getDisplayCountryDelegate _uloc_getDisplayCountry;
+
+		public static int uloc_getDisplayCountry(string localeID, string displayLocaleID,
+			IntPtr result, int maxResultSize, out ErrorCode err)
+		{
+			if (_uloc_getDisplayCountry == null)
+				_uloc_getDisplayCountry = GetMethod<uloc_getDisplayCountryDelegate>(IcuCommonLibHandle, "uloc_getDisplayCountry");
+			return _uloc_getDisplayCountry(localeID, displayLocaleID, result, maxResultSize, out err);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate int uloc_getDisplayVariantDelegate(string localeID, string displayLocaleID,
 			IntPtr result, int maxResultSize, out ErrorCode err);
 
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getDisplayVariant" + ICU_VERSION_SUFFIX,
-			CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_getDisplayVariant(string localeID, string displayLocaleID,
-			IntPtr result, int maxResultSize, out ErrorCode err);
+		private static uloc_getDisplayVariantDelegate _uloc_getDisplayVariant;
 
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getName" + ICU_VERSION_SUFFIX,
-			CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_getName(string localeID, IntPtr name,
+		public static int uloc_getDisplayVariant(string localeID, string displayLocaleID,
+			IntPtr result, int maxResultSize, out ErrorCode err)
+		{
+			if (_uloc_getDisplayVariant == null)
+				_uloc_getDisplayVariant = GetMethod<uloc_getDisplayVariantDelegate>(IcuCommonLibHandle, "uloc_getDisplayVariant");
+			return _uloc_getDisplayVariant(localeID, displayLocaleID, result, maxResultSize, out err);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate int uloc_getNameDelegate(string localeID, IntPtr name,
 			int nameCapacity, out ErrorCode err);
 
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_getName" + ICU_VERSION_SUFFIX,
-			CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_getBaseName(string localeID, IntPtr name,
+		private static uloc_getNameDelegate _uloc_getName;
+
+		public static int uloc_getName(string localeID, IntPtr name,
+			int nameCapacity, out ErrorCode err)
+		{
+			if (_uloc_getName == null)
+				_uloc_getName = GetMethod<uloc_getNameDelegate>(IcuCommonLibHandle, "uloc_getName");
+			return _uloc_getName(localeID, name, nameCapacity, out err);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate int uloc_getBaseNameDelegate(string localeID, IntPtr name,
 			int nameCapacity, out ErrorCode err);
 
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uloc_canonicalize" + ICU_VERSION_SUFFIX,
-			CallingConvention = CallingConvention.Cdecl)]
-		public static extern int uloc_canonicalize(string localeID, IntPtr name,
+		private static uloc_getBaseNameDelegate _uloc_getBaseName;
+
+		public static int uloc_getBaseName(string localeID, IntPtr name,
+			int nameCapacity, out ErrorCode err)
+		{
+			if (_uloc_getBaseName == null)
+				_uloc_getBaseName = GetMethod<uloc_getBaseNameDelegate>(IcuCommonLibHandle, "uloc_getBaseName");
+			return _uloc_getBaseName(localeID, name, nameCapacity, out err);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+		private delegate int uloc_canonicalizeDelegate(string localeID, IntPtr name,
 			int nameCapacity, out ErrorCode err);
+
+		private static uloc_canonicalizeDelegate _uloc_canonicalize;
+
+		public static int uloc_canonicalize(string localeID, IntPtr name,
+			int nameCapacity, out ErrorCode err)
+		{
+			if (_uloc_canonicalize == null)
+				_uloc_canonicalize = GetMethod<uloc_canonicalizeDelegate>(IcuCommonLibHandle, "uloc_canonicalize");
+			var res = _uloc_canonicalize(localeID, name, nameCapacity, out err);
+			return res;
+		}
 
 		#endregion
 
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int u_strToLowerDelegate(IntPtr dest, int destCapacity, string src, 
+			int srcLength, [MarshalAs(UnmanagedType.LPStr)] string locale, out ErrorCode errorCode);
+
+		private static u_strToLowerDelegate _u_strToLower;
+
 		/// <summary>Return the lower case equivalent of the string.</summary>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_strToLower" + ICU_VERSION_SUFFIX,
-			CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern int u_strToLower(IntPtr dest,
-			int destCapacity, string src, int srcLength,
-			[MarshalAs(UnmanagedType.LPStr)] string locale, out ErrorCode errorCode);
+		public static int u_strToLower(IntPtr dest, int destCapacity, string src, 
+			int srcLength, [MarshalAs(UnmanagedType.LPStr)] string locale, out ErrorCode errorCode)
+		{
+			if (_u_strToLower == null)
+				_u_strToLower = GetMethod<u_strToLowerDelegate>(IcuCommonLibHandle, "u_strToLower");
+			return _u_strToLower(dest, destCapacity, src, srcLength, locale, out errorCode);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int u_strToTitleDelegate(IntPtr dest, int destCapacity, string src,
+			int srcLength, IntPtr titleIter, [MarshalAs(UnmanagedType.LPStr)] string locale,
+			out ErrorCode errorCode);
+
+		private static u_strToTitleDelegate _u_strToTitle;
 
 		/// <summary>Return the title case equivalent of the string.</summary>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_strToTitle" + ICU_VERSION_SUFFIX,
-			CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern int u_strToTitle(IntPtr dest,
-			int destCapacity, string src, int srcLength, IntPtr titleIter,
-			[MarshalAs(UnmanagedType.LPStr)] string locale, out ErrorCode errorCode);
+		public static int u_strToTitle(IntPtr dest, int destCapacity, string src,
+			int srcLength, IntPtr titleIter, [MarshalAs(UnmanagedType.LPStr)] string locale,
+			out ErrorCode errorCode)
+		{
+			if (_u_strToTitle == null)
+				_u_strToTitle = GetMethod<u_strToTitleDelegate>(IcuCommonLibHandle, "u_strToTitle");
+			return _u_strToTitle(dest, destCapacity, src, srcLength, titleIter,
+				locale, out errorCode);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int u_strToUpperDelegate(IntPtr dest, int destCapacity, string src,
+			int srcLength, [MarshalAs(UnmanagedType.LPStr)] string locale, out ErrorCode errorCode);
+
+		private static u_strToUpperDelegate _u_strToUpper;
 
 		/// <summary>Return the upper case equivalent of the string.</summary>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "u_strToUpper" + ICU_VERSION_SUFFIX,
-			CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern int u_strToUpper(IntPtr dest,
-			int destCapacity, string src, int srcLength,
-			[MarshalAs(UnmanagedType.LPStr)] string locale, out ErrorCode errorCode);
+		public static int u_strToUpper(IntPtr dest, int destCapacity, string src,
+			int srcLength, [MarshalAs(UnmanagedType.LPStr)] string locale, out ErrorCode errorCode)
+		{
+			if (_u_strToUpper == null)
+				_u_strToUpper = GetMethod<u_strToUpperDelegate>(IcuCommonLibHandle, "u_strToUpper");
+			return _u_strToUpper(dest, destCapacity, src, srcLength, locale, out errorCode);
+		}
 
 		#region normalize
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int unorm_normalizeDelegate(string source, int sourceLength,
+			Normalizer.UNormalizationMode mode, int options,
+			IntPtr result, int resultLength, out ErrorCode errorCode);
+
+		private static unorm_normalizeDelegate _unorm_normalize;
+
 		/// <summary>
 		/// Normalize a string according to the given mode and options.
 		/// </summary>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "unorm_normalize" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern int unorm_normalize(string source, int sourceLength,
-												  Normalizer.UNormalizationMode mode, int options,
-												  IntPtr result, int resultLength, out ErrorCode errorCode);
+		public static int unorm_normalize(string source, int sourceLength,
+			Normalizer.UNormalizationMode mode, int options,
+			IntPtr result, int resultLength, out ErrorCode errorCode)
+		{
+			if (_unorm_normalize == null)
+				_unorm_normalize = GetMethod<unorm_normalizeDelegate>(IcuCommonLibHandle, "unorm_normalize");
+			return _unorm_normalize(source, sourceLength, mode, options, result,
+				resultLength, out errorCode);
+		}
+
+		// Note that ICU's UBool type is typedef to an 8-bit integer.
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate byte unorm_isNormalizedDelegate(string source,int sourceLength,
+			Normalizer.UNormalizationMode mode,out ErrorCode errorCode);
+
+		private static unorm_isNormalizedDelegate _unorm_isNormalized;
 
 		/// <summary>
 		/// Check whether a string is normalized according to the given mode and options.
 		/// </summary>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "unorm_isNormalized" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		// Note that ICU's UBool type is typedef to an 8-bit integer.
-		public static extern byte unorm_isNormalized(string source, int sourceLength,
-													 Normalizer.UNormalizationMode mode, out ErrorCode errorCode);
+		public static byte unorm_isNormalized(string source, int sourceLength,
+			Normalizer.UNormalizationMode mode, out ErrorCode errorCode)
+		{
+			if (_unorm_isNormalized == null)
+				_unorm_isNormalized = GetMethod<unorm_isNormalizedDelegate>(IcuCommonLibHandle, "unorm_isNormalized");
+			return _unorm_isNormalized(source, sourceLength, mode, out errorCode);
+		}
+
 		#endregion normalize
 
 		#region Break iterator
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate IntPtr ubrk_openDelegate(BreakIterator.UBreakIteratorType type,
+			string locale, string text, int textLength, out ErrorCode errorCode);
+
+		private static ubrk_openDelegate _ubrk_open;
 
 		/// <summary>
 		/// Open a new UBreakIterator for locating text boundaries for a specified locale.
@@ -1379,66 +2201,124 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// <param name="textLength">Length of the text.</param>
 		/// <param name="errorCode">The error code.</param>
 		/// <returns></returns>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "ubrk_open" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern IntPtr ubrk_open(BreakIterator.UBreakIteratorType type, string locale,
-											   string text, int textLength, out ErrorCode errorCode);
+		public static IntPtr ubrk_open(BreakIterator.UBreakIteratorType type,
+			string locale, string text, int textLength, out ErrorCode errorCode)
+		{
+			if (_ubrk_open == null)
+				_ubrk_open = GetMethod<ubrk_openDelegate>(IcuCommonLibHandle, "ubrk_open");
+			return _ubrk_open(type, locale, text, textLength, out errorCode);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate void ubrk_closeDelegate(IntPtr bi);
+
+		private static ubrk_closeDelegate _ubrk_close;
 
 		/// <summary>
 		/// Close a UBreakIterator.
 		/// </summary>
 		/// <param name="bi">The break iterator.</param>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "ubrk_close" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern void ubrk_close(IntPtr bi);
+		public static void ubrk_close(IntPtr bi)
+		{
+			if (_ubrk_close == null)
+				_ubrk_close = GetMethod<ubrk_closeDelegate>(IcuCommonLibHandle, "ubrk_close");
+			_ubrk_close(bi);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int ubrk_firstDelegate(IntPtr bi);
+
+		private static ubrk_firstDelegate _ubrk_first;
 
 		/// <summary>
 		/// Determine the index of the first character in the text being scanned.
 		/// </summary>
 		/// <param name="bi">The break iterator.</param>
 		/// <returns></returns>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "ubrk_first" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern int ubrk_first(IntPtr bi);
+		public static int ubrk_first(IntPtr bi)
+		{
+			if (_ubrk_first == null)
+				_ubrk_first = GetMethod<ubrk_firstDelegate>(IcuCommonLibHandle, "ubrk_first");
+			return _ubrk_first(bi);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int ubrk_nextDelegate(IntPtr bi);
+
+		private static ubrk_nextDelegate _ubrk_next;
 
 		/// <summary>
 		/// Determine the text boundary following the current text boundary.
 		/// </summary>
 		/// <param name="bi">The break iterator.</param>
 		/// <returns></returns>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "ubrk_next" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern int ubrk_next(IntPtr bi);
+		public static int ubrk_next(IntPtr bi)
+		{
+			if (_ubrk_next == null)
+				_ubrk_next = GetMethod<ubrk_nextDelegate>(IcuCommonLibHandle, "ubrk_next");
+			return _ubrk_next(bi);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int ubrk_getRuleStatusDelegate(IntPtr bi);
+
+		private static ubrk_getRuleStatusDelegate _ubrk_getRuleStatus;
 
 		/// <summary>
 		/// Return the status from the break rule that determined the most recently returned break position.
 		/// </summary>
 		/// <param name="bi">The break iterator.</param>
 		/// <returns></returns>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "ubrk_getRuleStatus" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern int ubrk_getRuleStatus(IntPtr bi);
+		public static int ubrk_getRuleStatus(IntPtr bi)
+		{
+			if (_ubrk_getRuleStatus == null)
+				_ubrk_getRuleStatus = GetMethod<ubrk_getRuleStatusDelegate>(IcuCommonLibHandle, "ubrk_getRuleStatus");
+			return _ubrk_getRuleStatus(bi);
+		}
+
 		#endregion Break iterator
 
 		#region Unicode set
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate void uset_closeDelegate(IntPtr set);
+
+		private static uset_closeDelegate _uset_close;
 
 		/// <summary>
 		/// Disposes of the storage used by Unicode set.  This function should be called exactly once for objects returned by uset_open()
 		/// </summary>
 		/// <param name="set">Unicode set to dispose of </param>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uset_close" + ICU_VERSION_SUFFIX, CallingConvention = CallingConvention.Cdecl)]
-		public static extern void uset_close(IntPtr set);
+		public static void uset_close(IntPtr set)
+		{
+			if (_uset_close == null)
+				_uset_close = GetMethod<uset_closeDelegate>(IcuCommonLibHandle, "uset_close");
+			_uset_close(set);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate IntPtr uset_openDelegate(char start,char end);
+
+		private static uset_openDelegate _uset_open;
 
 		/// <summary>
 		/// Creates a Unicode set that contains the range of characters start..end, inclusive.
-		/// If start > end then an empty set is created (same as using uset_openEmpty()).
+		/// If start > end then an empty set is created (same as using uset_openEmpty().
 		/// </summary>
 		/// <param name="start">First character of the range, inclusive</param>
 		/// <param name="end">Last character of the range, inclusive</param>
 		/// <returns>Unicode set of characters.  The caller must call uset_close() on it when done</returns>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uset_open" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern IntPtr uset_open(char start, char end);
+		public static IntPtr uset_open(char start, char end)
+		{
+			if (_uset_open == null)
+				_uset_open = GetMethod<uset_openDelegate>(IcuCommonLibHandle, "uset_open");
+			return _uset_open(start, end);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate IntPtr uset_openPatternDelegate(string pattern,int patternLength,ref ErrorCode status);
+
+		private static uset_openPatternDelegate _uset_openPattern;
 
 		/// <summary>
 		/// Creates a set from the given pattern.
@@ -1447,18 +2327,35 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// <param name="patternLength">Length of the pattern, or -1 if null terminated</param>
 		/// <param name="status">The error code</param>
 		/// <returns>Unicode set</returns>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uset_openPattern" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern IntPtr uset_openPattern(string pattern, int patternLength, ref ErrorCode status);
+		public static IntPtr uset_openPattern(string pattern, int patternLength, ref ErrorCode status)
+		{
+			if (_uset_openPattern == null)
+				_uset_openPattern = GetMethod<uset_openPatternDelegate>(IcuCommonLibHandle, "uset_openPattern");
+			return _uset_openPattern(pattern, patternLength, ref status);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate void uset_addDelegate(IntPtr set,char c);
+
+		private static uset_addDelegate _uset_add;
 
 		/// <summary>
 		/// Adds the given character to the given Unicode set.  After this call, uset_contains(set, c) will return TRUE.  A frozen set will not be modified.
 		/// </summary>
 		/// <param name="set">The object to which to add the character</param>
 		/// <param name="c">The character to add</param>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uset_add" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern void uset_add(IntPtr set, char c);
+		public static void uset_add(IntPtr set, char c)
+		{
+			if (_uset_add == null)
+				_uset_add = GetMethod<uset_addDelegate>(IcuCommonLibHandle, "uset_add");
+			_uset_add(set, c);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int uset_toPatternDelegate(IntPtr set, IntPtr result, int resultCapacity,
+			bool escapeUnprintable, ref ErrorCode status);
+
+		private static uset_toPatternDelegate _uset_toPattern;
 
 		/// <summary>
 		/// Returns a string representation of this set.  If the result of calling this function is 
@@ -1471,10 +2368,18 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// \uxxxx or \Uxxxxxxxx. Unprintable characters are those other than U+000A, U+0020..U+007E.</param>
 		/// <param name="status">Error code</param>
 		/// <returns>Length of string, possibly larger than resultCapacity</returns>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uset_toPattern" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern int uset_toPattern(IntPtr set, IntPtr result, int resultCapacity,
-			bool escapeUnprintable, ref ErrorCode status);
+		public static int uset_toPattern(IntPtr set, IntPtr result, int resultCapacity,
+			bool escapeUnprintable, ref ErrorCode status)
+		{
+			if (_uset_toPattern == null)
+				_uset_toPattern = GetMethod<uset_toPatternDelegate>(IcuCommonLibHandle, "uset_toPattern");
+			return _uset_toPattern(set, result, resultCapacity, escapeUnprintable, ref status);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate void uset_addStringDelegate(IntPtr set,string str,int strLen);
+
+		private static uset_addStringDelegate _uset_addString;
 
 		/// <summary>
 		/// Adds the given string to the given Unicode set
@@ -1482,10 +2387,18 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// <param name="set">The Unicode set to which to add the string</param>
 		/// <param name="str">The string to add</param>
 		/// <param name="strLen">The length of the string or -1 if null</param>
-		/// 
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uset_addString" + ICU_VERSION_SUFFIX,
-				CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern void uset_addString(IntPtr set, string str, int strLen);
+		public static void uset_addString(IntPtr set, string str, int strLen)
+		{
+			if (_uset_addString == null)
+				_uset_addString = GetMethod<uset_addStringDelegate>(IcuCommonLibHandle, "uset_addString");
+			_uset_addString(set, str, strLen);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int uset_getItemDelegate(IntPtr set, int itemIndex, out int start,
+			out int end, IntPtr str, int strCapacity, ref ErrorCode ec);
+
+		private static uset_getItemDelegate _uset_getItem;
 
 		/// <summary>
 		/// Returns an item of this Unicode set.  An item is either a range of characters or a single multicharacter string.
@@ -1498,20 +2411,31 @@ ucol_nextSortKeyPart(SafeRuleBasedCollatorHandle collator,
 		/// <param name="strCapacity">Capcacity of str, or 0 if str is NULL</param>
 		/// <param name="ec">Error Code</param>
 		/// <returns>The length of the string (>=2), or 0 if the item is a range, in which case it is the range *start..*end, or -1 if itemIndex is out of range</returns>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uset_getItem" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern int uset_getItem(IntPtr set, int itemIndex, out int start, out int end, IntPtr str,
-			int strCapacity, ref ErrorCode ec);
+		public static int uset_getItem(IntPtr set, int itemIndex, out int start,
+			out int end, IntPtr str, int strCapacity, ref ErrorCode ec)
+		{
+			if (_uset_getItem == null)
+				_uset_getItem = GetMethod<uset_getItemDelegate>(IcuCommonLibHandle, "uset_getItem");
+			return _uset_getItem(set, itemIndex, out start, out end, str, strCapacity, ref ec);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int uset_getItemCountDelegate(IntPtr set);
+
+		private static uset_getItemCountDelegate _uset_getItemCount;
 
 		/// <summary>
 		/// Returns the number of items in this set.  An item is either a range of characters or a single multicharacter string
 		/// </summary>
 		/// <param name="set">The Unicode set</param>
 		/// <returns>A non-negative integer counting the character ranges and/or strings contained in the set</returns>
-		[DllImport(ICU_COMMON_LIB, EntryPoint = "uset_getItemCount" + ICU_VERSION_SUFFIX,
-				   CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		public static extern int uset_getItemCount(IntPtr set);
+		public static int uset_getItemCount(IntPtr set)
+		{
+			if (_uset_getItemCount == null)
+				_uset_getItemCount = GetMethod<uset_getItemCountDelegate>(IcuCommonLibHandle, "uset_getItemCount");
+			return _uset_getItemCount(set);
+		}
 
-		#endregion Unicode set
+		#endregion // Unicode set
 	}
 }


### PR DESCRIPTION
This allows the library to work with multiple ICU versions. This makes
it easier to produce a nuget package that works with any ICU version
(rather than having to create a separate package for each ICU version),
and it allows to use the same binary/nuget package for different
Linux versions which come pre-installed with different ICU versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/11)
<!-- Reviewable:end -->
