### PR TITLE
Allow to limit considered ICU version

### DIFF
--- a/source/icu.net/IcuWrapper.cs
+++ b/source/icu.net/IcuWrapper.cs
@@ -39,6 +39,25 @@ namespace Icu
 		}
 		#endregion
 
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Limits the ICU versions that are considered when trying to dynamically load ICU.
+		/// </summary>
+		/// <remarks>This method allows an application to select a specific ICU version. Otherwise
+		/// the highest found supported ICU libraries will be used.</remarks>
+		/// <param name="minIcuVersion">Minimum ICU version. Needs to be greater or equal to the
+		/// minimum supported ICU version (currently 44).</param>
+		/// <param name="maxIcuVersion">Maximum ICU version. Needs to be less or equal to the
+		/// maximum supported ICU version (currently 60). Set to <c>-1</c> to use the same value
+		/// as <paramref name="minIcuVersion"/>.</param>
+		/// ------------------------------------------------------------------------------------
+		public static void ConfineIcuVersions(int minIcuVersion, int maxIcuVersion = -1)
+		{
+			if (maxIcuVersion == -1)
+				maxIcuVersion = minIcuVersion;
+			NativeMethods.SetMinMaxIcuVersions(minIcuVersion, maxIcuVersion);
+		}
+
 		#region Public wrappers around the ICU methods
 
 

--- a/source/icu.net/NativeMethods.cs
+++ b/source/icu.net/NativeMethods.cs
@@ -9,8 +9,29 @@ namespace Icu
 {
 	internal static class NativeMethods
 	{
-		private const int minIcuVersion = 44;
-		private const int maxIcuVersion = 60;
+		private const int MinIcuVersionDefault = 44;
+		private const int MaxIcuVersionDefault = 60;
+		private static int minIcuVersion = MinIcuVersionDefault;
+		private static int maxIcuVersion = MaxIcuVersionDefault;
+
+		public static void SetMinMaxIcuVersions(int minVersion = MinIcuVersionDefault,
+			int maxVersion = MaxIcuVersionDefault)
+		{
+			if (minVersion < MinIcuVersionDefault || minVersion > MaxIcuVersionDefault)
+			{
+				throw new ArgumentOutOfRangeException("minVersion",
+					string.Format("supported ICU versions are between {0} and {1}",
+					MinIcuVersionDefault, MaxIcuVersionDefault));
+			}
+			if (maxVersion < MinIcuVersionDefault || maxVersion > MaxIcuVersionDefault)
+			{
+				throw new ArgumentOutOfRangeException("maxVersion",
+					string.Format("supported ICU versions are between {0} and {1}",
+					MinIcuVersionDefault, MaxIcuVersionDefault));
+			}
+			minIcuVersion = Math.Min(minVersion, maxVersion);
+			maxIcuVersion = Math.Max(minVersion, maxVersion);
+		}
 
 		#region Dynamic method loading
 


### PR DESCRIPTION
This allows an application to select a specific (range of) ICU
version that the library attempts to load.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/12)
<!-- Reviewable:end -->
