### PR TITLE
Support .NET Culture identifiers when using Collator

### DIFF
--- a/source/icu.net.tests/Collation/CollatorTests.cs
+++ b/source/icu.net.tests/Collation/CollatorTests.cs
@@ -20,6 +20,23 @@ namespace Icu.Tests.Collation
 
 		[Test]
 		[Category("Full ICU")]
+		//This fails when ICU's data DLL is built without rules for the en-US locale.
+		public void Create_LocaleWithCultureInfo()
+		{
+			var cultureInfo = new CultureInfo("en-US");
+			Assert.That(Collator.Create(cultureInfo.Name), Is.Not.Null);
+		}
+
+		[Test]
+		[Category("Full ICU")]
+		//This fails when ICU's data DLL is built without rules for the en-US locale.
+		public void Create_LocaleWithICUCultureId()
+		{
+			Assert.That(Collator.Create("en_US"), Is.Not.Null);
+		}
+
+		[Test]
+		[Category("Full ICU")]
 		//This fails when ICU's data DLL is built without rules for the root locale.
 		public void Create_RootLocale()
 		{

--- a/source/icu.net/Collation/RuleBasedCollator.cs
+++ b/source/icu.net/Collation/RuleBasedCollator.cs
@@ -353,9 +353,14 @@ namespace Icu.Collation
 
 		public static new Collator Create(string localeId, Fallback fallback)
 		{
+			// Culture identifiers in .NET are created using '-', while ICU
+			// expects '_'.  We want to make sure that the localeId is the
+			// format that ICU expects.
+			var locale = new Locale(localeId);
+
 			RuleBasedCollator instance = new RuleBasedCollator();
 			ErrorCode status;
-			instance._collatorHandle = NativeMethods.ucol_open(localeId, out status);
+			instance._collatorHandle = NativeMethods.ucol_open(locale.Id, out status);
 			if(status == ErrorCode.USING_FALLBACK_WARNING && fallback == Fallback.NoFallback)
 			{
 				throw new ArgumentException("Could only create Collator '" +
@@ -364,8 +369,8 @@ namespace Icu.Collation
 											instance.ActualId +
 											"'. You can use the fallback option to create this.");
 			}
-			if(status == ErrorCode.USING_DEFAULT_WARNING && fallback == Fallback.NoFallback && instance.ValidId != localeId &&
-				 localeId.Length > 0 && localeId != "root")
+			if(status == ErrorCode.USING_DEFAULT_WARNING && fallback == Fallback.NoFallback && !instance.ValidId.Equals(locale.Id) &&
+				 locale.Id.Length > 0 && !locale.Id.Equals("root"))
 			{
 				throw new ArgumentException("Could only create Collator '" +
 											localeId +


### PR DESCRIPTION
An ArgumentException is thrown when using .NET locale names because they use en-US as an identifier whereas, ICU uses en_US.  To fix this, canonize all given localeIds by creating a Locale object before passing it to Collator.Create method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/17)
<!-- Reviewable:end -->
