### PR TITLE
Fix Collator.GetCollationRules

### DIFF
--- a/source/icu.net.tests/Collation/RuleBasedCollatorTests.cs
+++ b/source/icu.net.tests/Collation/RuleBasedCollatorTests.cs
@@ -813,5 +813,43 @@ namespace Icu.Tests.Collation
 				() => new RuleBasedCollator(IcuStart + "a << \udc00\ud800")
 			);
 		}
+
+		/// <summary>
+		/// Tailored rules were obtained from:
+		/// http://source.icu-project.org/repos/icu/icu/tags/release-56-1/source/data/coll/sr.txt
+		/// </summary>
+		[Test]
+		public void GetSortRules_Serbian()
+		{
+			const string rules = "[reorder Cyrl][suppressContractions [Ии]]";
+			const string language = "sr";
+			var locale = new Locale(language);
+
+			var collationRules = Collator.GetCollationRules(locale);
+			var collationRules2 = Collator.GetCollationRules(language);
+
+			Assert.AreEqual(rules, collationRules);
+			Assert.AreEqual(collationRules, collationRules2);
+		}
+
+		/// <summary>
+		/// Getting CollationRules for English should return some content.
+		/// Before it would return NULL because the ErrorCode returned was
+		/// ErrorCode.USING_DEFAULT_WARNING which is not a failure.
+		///
+		/// Double-check this to make sure the rules are correct.
+		/// http://source.icu-project.org/repos/icu/icu/tags/release-56-1/source/data/coll/en.txt
+		/// </summary>
+		[Test]
+		public void GetSortRules_English()
+		{
+			var locale = new Locale("en-US");
+
+			var tailoredRules = Collator.GetCollationRules(locale);
+			var collationRules = Collator.GetCollationRules(locale, UColRuleOption.UCOL_FULL_RULES);
+
+			Assert.IsEmpty(tailoredRules);
+			Assert.IsNotNullOrEmpty(collationRules);
+		}
 	}
 }

--- a/source/icu.net/Collation/Collator.cs
+++ b/source/icu.net/Collation/Collator.cs
@@ -221,25 +221,35 @@ namespace Icu.Collation
 		/// Gets the collation rules for the specified locale.
 		/// </summary>
 		/// <param name="locale">The locale.</param>
-		/// <returns></returns>
-		public static string GetCollationRules(string locale)
+		/// <param name="collatorRuleOption">UColRuleOption to use. Default is UColRuleOption.UCOL_TAILORING_ONLY</param>
+		public static string GetCollationRules(string locale, UColRuleOption collatorRuleOption = UColRuleOption.UCOL_TAILORING_ONLY)
+		{
+			return GetCollationRules(new Locale(locale), collatorRuleOption);
+		}
+
+		/// <summary>
+		/// Gets the collation rules for the specified locale.
+		/// </summary>
+		/// <param name="locale">The locale.</param>
+		/// <param name="collatorRuleOption">UColRuleOption to use. Default is UColRuleOption.UCOL_TAILORING_ONLY</param>
+		public static string GetCollationRules(Locale locale, UColRuleOption collatorRuleOption = UColRuleOption.UCOL_TAILORING_ONLY)
 		{
 			ErrorCode err;
-			using (RuleBasedCollator.SafeRuleBasedCollatorHandle coll = NativeMethods.ucol_open(locale, out err))
+			using (RuleBasedCollator.SafeRuleBasedCollatorHandle coll = NativeMethods.ucol_open(locale.Id, out err))
 			{
-				if (coll.IsInvalid || err != ErrorCode.NoErrors)
+				if (coll.IsInvalid || err.IsFailure())
 					return null;
 
 				const int len = 1000;
 				IntPtr buffer = Marshal.AllocCoTaskMem(len * 2);
 				try
 				{
-					int actualLen = NativeMethods.ucol_getRulesEx(coll, UColRuleOption.UCOL_TAILORING_ONLY, buffer, len);
+					int actualLen = NativeMethods.ucol_getRulesEx(coll, collatorRuleOption, buffer, len);
 					if (actualLen > len)
 					{
 						Marshal.FreeCoTaskMem(buffer);
 						buffer = Marshal.AllocCoTaskMem(actualLen * 2);
-						NativeMethods.ucol_getRulesEx(coll, UColRuleOption.UCOL_TAILORING_ONLY, buffer, actualLen);
+						NativeMethods.ucol_getRulesEx(coll, collatorRuleOption, buffer, actualLen);
 					}
 					return Marshal.PtrToStringUni(buffer, actualLen);
 				}


### PR DESCRIPTION
* Collator.GetCollationRules would return `null` because it was checking for `err != ErrorCode.NoErrors`. Modified to use `err.IsFailure()` like in BreakIterator
* Modified method to also take in a UColRuleOption if full rules are desired
* Added tests44

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/19)
<!-- Reviewable:end -->
