### PR TITLE
Prefer local directory when loading unmanaged ICU

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,4 @@
 *.svg -whitespace
 *.xml -whitespace
 changelog -whitespace
+GitVersion.yml -whitespace

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,8 +1,10 @@
 mode: ContinuousDeployment
-next-version: 2.0.0
 branches:
   master:
-    regex: (origin/)?master
     tag: beta
+    regex: (origin/)?master
+  pull-request:
+    mode: ContinuousDeployment
+    tag: PR
 ignore:
   sha: []

--- a/source/TestHelper/Properties/AssemblyInfo.cs
+++ b/source/TestHelper/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TestHelper")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TestHelper")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f195adce-9129-446e-85e0-8eead01ed08d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/TestHelper/TestHelper.cs
+++ b/source/TestHelper/TestHelper.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+using System;
+using System.IO;
+
+namespace Icu.Tests
+{
+	class TestHelper
+	{
+		static void Main(string[] args)
+		{
+			try
+			{
+				Console.WriteLine(Wrapper.IcuVersion);
+			}
+			catch (FileLoadException)
+			{
+				// Ignore - means we can't load ICU
+			}
+		}
+	}
+}

--- a/source/TestHelper/TestHelper.csproj
+++ b/source/TestHelper/TestHelper.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F195ADCE-9129-446E-85E0-8EEAD01ED08D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Icu.Tests</RootNamespace>
+    <AssemblyName>TestHelper</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\output\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\output\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="TestHelper.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\icu.net\icu.net.csproj">
+      <Project>{28a0072f-ae0b-449a-8494-b53f09756273}</Project>
+      <Name>icu.net</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/source/icu.net.sln
+++ b/source/icu.net.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 2013
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "icu.net", "icu.net\icu.net.csproj", "{28A0072F-AE0B-449A-8494-B53F09756273}"
 EndProject
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.nuget\packages.config = .nuget\packages.config
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestHelper", "TestHelper\TestHelper.csproj", "{F195ADCE-9129-446E-85E0-8EEAD01ED08D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -72,8 +74,32 @@ Global
 		{9D7CFEF4-55F1-4C31-9B7B-EB6520AE4EDB}.ReleaseMono|Mixed Platforms.Build.0 = ReleaseMono|Any CPU
 		{9D7CFEF4-55F1-4C31-9B7B-EB6520AE4EDB}.ReleaseMono|x86.ActiveCfg = ReleaseMono|x86
 		{9D7CFEF4-55F1-4C31-9B7B-EB6520AE4EDB}.ReleaseMono|x86.Build.0 = ReleaseMono|x86
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.Debug|x86.Build.0 = Debug|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.DebugMono|Any CPU.ActiveCfg = Debug|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.DebugMono|Any CPU.Build.0 = Debug|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.DebugMono|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.DebugMono|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.DebugMono|x86.ActiveCfg = Debug|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.DebugMono|x86.Build.0 = Debug|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.Release|x86.ActiveCfg = Release|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.Release|x86.Build.0 = Release|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.ReleaseMono|Any CPU.ActiveCfg = Release|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.ReleaseMono|Any CPU.Build.0 = Release|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.ReleaseMono|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.ReleaseMono|Mixed Platforms.Build.0 = Release|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.ReleaseMono|x86.ActiveCfg = Release|Any CPU
+		{F195ADCE-9129-446E-85E0-8EEAD01ED08D}.ReleaseMono|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0
@@ -81,8 +107,5 @@ Global
 		$1.Text = @Copyright (c) ${Year} SIL International\nThis software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 		$1.IncludeInNewFiles = True
 		StartupItem = icu.net\icu.net.csproj
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/source/icu.net.tests/NativeMethodsTests.cs
+++ b/source/icu.net.tests/NativeMethodsTests.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Icu.Tests
+{
+	[TestFixture]
+	[Platform(Exclude = "Linux",
+		Reason = "These tests require ICU4C installed from NuGet packages which isn't available on Linux")]
+	public class NativeMethodsTests
+	{
+		private string _tmpDir;
+		private string _path;
+
+		private static void CopyFile(string srcPath, string dstDir)
+		{
+			var fileName = Path.GetFileName(srcPath);
+			File.Copy(srcPath, Path.Combine(dstDir, fileName));
+		}
+
+		private static string OutputDirectory
+		{
+			get { return Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).AbsolutePath); }
+		}
+
+		private string RunTestHelper(string dir)
+		{
+			using (var process = new Process())
+			{
+				process.StartInfo.RedirectStandardError = false;
+				process.StartInfo.RedirectStandardOutput = true;
+				process.StartInfo.UseShellExecute = false;
+				process.StartInfo.CreateNoWindow = true;
+				process.StartInfo.WorkingDirectory = dir;
+				process.StartInfo.FileName = Path.Combine(_tmpDir, "TestHelper.exe");
+
+				process.Start();
+				var output = process.StandardOutput.ReadToEnd();
+				process.WaitForExit();
+				return output.TrimEnd('\r', '\n');
+			}
+		}
+
+		[SetUp]
+		public void Setup()
+		{
+			_tmpDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+			Directory.CreateDirectory(_tmpDir);
+			var sourceDir = OutputDirectory;
+			CopyFile(Path.Combine(sourceDir, "TestHelper.exe"), _tmpDir);
+			CopyFile(Path.Combine(sourceDir, "icu.net.dll"), _tmpDir);
+
+			_path = Environment.GetEnvironmentVariable("PATH");
+			var path = string.Format("{0}{1}{2}", OutputDirectory, Path.PathSeparator,
+				_path);
+			Environment.SetEnvironmentVariable("PATH", path);
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			Directory.Delete(_tmpDir, true);
+			Environment.SetEnvironmentVariable("PATH", _path);
+		}
+
+		[Test]
+		public void LoadIcuLibrary_GetFromPath()
+		{
+			Assert.That(RunTestHelper(_tmpDir), Is.EqualTo("56.1"));
+		}
+
+		[Test]
+		public void LoadIcuLibrary_GetFromPathDifferentDir()
+		{
+			Assert.That(RunTestHelper(Path.GetTempPath()), Is.EqualTo("56.1"));
+		}
+
+		[Test]
+		public void LoadIcuLibrary_LoadLocalVersion()
+		{
+			CopyFile(Path.Combine(OutputDirectory, "icudt54.dll"), _tmpDir);
+			CopyFile(Path.Combine(OutputDirectory, "icuin54.dll"), _tmpDir);
+			CopyFile(Path.Combine(OutputDirectory, "icuuc54.dll"), _tmpDir);
+			Assert.That(RunTestHelper(_tmpDir), Is.EqualTo("54.1"));
+		}
+
+		[Test]
+		public void LoadIcuLibrary_LoadLocalVersionDifferentPath()
+		{
+			CopyFile(Path.Combine(OutputDirectory, "icudt54.dll"), _tmpDir);
+			CopyFile(Path.Combine(OutputDirectory, "icuin54.dll"), _tmpDir);
+			CopyFile(Path.Combine(OutputDirectory, "icuuc54.dll"), _tmpDir);
+			Assert.That(RunTestHelper(Path.GetTempPath()), Is.EqualTo("54.1"));
+		}
+	}
+}

--- a/source/icu.net.tests/icu.net.tests.csproj
+++ b/source/icu.net.tests/icu.net.tests.csproj
@@ -125,6 +125,7 @@
     <Compile Include="BreakIteratorTests.Chinese.cs" />
     <Compile Include="Collation\CollatorTests.cs" />
     <Compile Include="Collation\SortKeyTests.cs" />
+    <Compile Include="NativeMethodsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Collation\RuleBasedCollatorTests.cs" />
     <Compile Include="LocaleTests.cs" />
@@ -187,5 +188,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Icu4c.Win.Full.Lib.56.1.5\build\Icu4c.Win.Full.Lib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Icu4c.Win.Full.Lib.56.1.5\build\Icu4c.Win.Full.Lib.targets'))" />
+    <Error Condition="!Exists('..\packages\Icu4c.Win.Min.54.1.31\build\Icu4c.Win.Min.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Icu4c.Win.Min.54.1.31\build\Icu4c.Win.Min.targets'))" />
   </Target>
+  <Import Project="..\packages\Icu4c.Win.Min.54.1.31\build\Icu4c.Win.Min.targets" Condition="Exists('..\packages\Icu4c.Win.Min.54.1.31\build\Icu4c.Win.Min.targets')" />
 </Project>

--- a/source/icu.net.tests/packages.config
+++ b/source/icu.net.tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Icu4c.Win.Full.Lib" version="56.1.5" targetFramework="net40" />
+  <package id="Icu4c.Win.Min" version="54.1.31" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
If there are unmanaged ICU libraries in the same directory as icu.net.dll we will now use those even if we find a higher versioned ICU elsewhere on the path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/21)
<!-- Reviewable:end -->
