### PR TITLE
Update CollationStrength.Identical

### DIFF
--- a/source/icu.net.tests/Collation/RuleBasedCollatorTests.cs
+++ b/source/icu.net.tests/Collation/RuleBasedCollatorTests.cs
@@ -109,6 +109,16 @@ namespace Icu.Tests.Collation
 			Assert.IsNotNull(key.KeyData);
 		}
 
+		[Test]
+		public void SetCollatorStrengthToIdentical()
+		{
+			var collator = Collator.Create("zh");
+
+			collator.Strength = CollationStrength.Identical;
+
+			Assert.AreEqual(CollationStrength.Identical, collator.Strength);
+		}
+
 		[TestCase(CollationStrength.Tertiary, AlternateHandling.Shifted, "di Silva", "diSilva", Result = 0)]
 		[TestCase(CollationStrength.Tertiary, AlternateHandling.Shifted, "diSilva", "Di Silva", Result = -1)]
 		[TestCase(CollationStrength.Tertiary, AlternateHandling.Shifted, "U.S.A.", "USA", Result = 0)]

--- a/source/icu.net/Collation/CollationStrength.cs
+++ b/source/icu.net/Collation/CollationStrength.cs
@@ -52,6 +52,6 @@ namespace Icu.Collation
 		/// </summary>
 		/// <remarks>Identical strength is rarely useful, as it amounts to
 		/// codepoints of the NFD form of the string</remarks>
-		Identical
+		Identical = 15
 	}
 }


### PR DESCRIPTION
When trying to set Collator.Strength to Identical, it would return an "U_ILLEGAL_ARGUMENT_ERROR" because the enumeration value was incorrect.  This fixes that using the value in [ucol.h:Line 89](http://icu-project.org/apiref/icu4c/ucol_8h_source.html#l00089)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/22)
<!-- Reviewable:end -->
