### PR TITLE
Make BreakIterator closer to icu::BreakIterator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ test-results/
 *.suo
 source/packages/
 source/NuGetBuild/
+
+# Visual Studio 2015 cache/options directory
+.vs/

--- a/source/icu.net.tests/BreakIteratorTests.Chinese.cs
+++ b/source/icu.net.tests/BreakIteratorTests.Chinese.cs
@@ -52,5 +52,186 @@ namespace Icu.Tests
 			Assert.That(parts.Count(), Is.EqualTo(expected.Length));
 			Assert.That(parts.ToArray(), Is.EquivalentTo(expected));
 		}
+
+		[Test]
+		public void CreateWordInstanceTest()
+		{
+			if (string.CompareOrdinal(Wrapper.IcuVersion, "52.1") < 0)
+				Assert.Ignore("This test requires ICU 52 or higher");
+
+			var text = "你是中国人么？ 我喜欢你们的国家。";
+			var locale = new Locale("zh");
+			var expected = new[] {
+				new Boundary(0, 2), new Boundary(2, 5), new Boundary(5, 6), // 你是中国人么
+				new Boundary(6,7), new Boundary(7,8), new Boundary(8, 9), //？ 我
+				new Boundary(9, 11), new Boundary(11, 13), new Boundary(13, 14), // 喜欢你们的
+                new Boundary(14, 16), new Boundary(16, 17) // 国家。
+            };
+
+			using (var bi = BreakIterator.CreateWordInstance(locale, text, includeSpacesAndPunctuation: true))
+			{
+				Assert.AreEqual(text, bi.Text);
+				Assert.AreEqual(locale, bi.Locale);
+				CollectionAssert.AreEqual(expected, bi.Boundaries);
+			}
+		}
+
+		[Test]
+		public void CreateWordInstanceTest_IgnoreSpacesAndPunctuation()
+		{
+			if (string.CompareOrdinal(Wrapper.IcuVersion, "52.1") < 0)
+				Assert.Ignore("This test requires ICU 52 or higher");
+
+			var text = "你是中国人么？ 我喜欢你们的国家。";
+			var locale = new Locale("zh");
+			var expected = new[] {
+				new Boundary(0, 2), new Boundary(2, 5), new Boundary(5, 6), // 你是中国人么
+                new Boundary(8, 9), new Boundary(9, 11), new Boundary(11, 13), // 我喜欢你们
+                new Boundary(13, 14), new Boundary(14, 16) // 的国家
+            };
+
+			using (var bi = BreakIterator.CreateWordInstance(locale, text, includeSpacesAndPunctuation: false))
+			{
+				Assert.AreEqual(text, bi.Text);
+				Assert.AreEqual(locale, bi.Locale);
+				CollectionAssert.AreEqual(expected, bi.Boundaries);
+			}
+		}
+
+		[Test]
+		public void CreateSentenceInstanceTest()
+		{
+			var text = "供重呼車遊踏持図質腰大野明会掲歌? 方図強候準素能物第毎止田作昼野集。霊一起続時筑腺算掲断詳山住死示流投。";
+			var locale = new Locale("zh");
+			var expected = new[] { new Boundary(0, 18), new Boundary(18, 35), new Boundary(35, 53) };
+
+			using (var bi = BreakIterator.CreateSentenceInstance(locale, text))
+			{
+				Assert.AreEqual(locale, bi.Locale);
+				CollectionAssert.AreEqual(expected, bi.Boundaries);
+			}
+		}
+
+		[Test]
+		public void CanIterateForwards()
+		{
+			var text = "供重呼車遊踏持図質腰大野明会掲歌? 方図強候準素能物第毎止田作昼野集。霊一起続時筑腺算掲断詳山住死示流投。";
+			var locale = new Locale("zh");
+			var expected = new[] { new Boundary(0, 18), new Boundary(18, 35), new Boundary(35, 53) };
+
+			using (var bi = BreakIterator.CreateSentenceInstance(locale, text))
+			{
+				CollectionAssert.AreEqual(expected, bi.Boundaries);
+
+				int current = 0;
+				var currentBoundary = expected[current];
+				Assert.AreEqual(currentBoundary, bi.Current);
+
+				// increment the index and verify that the next Boundary is correct.
+				current++;
+				currentBoundary = expected[current];
+				Assert.AreEqual(currentBoundary, bi.Next);
+				Assert.AreEqual(currentBoundary, bi.Current);
+
+				current++;
+				currentBoundary = expected[current];
+				Assert.AreEqual(currentBoundary, bi.Next);
+				Assert.AreEqual(currentBoundary, bi.Current);
+
+				// We've moved past the last word, it should return null.
+				Assert.Null(bi.Next);
+				Assert.Null(bi.Current);
+
+				// Verify that the first element is correct now that we've moved to the end.
+				Assert.AreEqual(expected[0], bi.First);
+				Assert.AreEqual(expected[0], bi.Current);
+			}
+		}
+
+		[Test]
+		public void CanIterateBackwards()
+		{
+			if (string.CompareOrdinal(Wrapper.IcuVersion, "52.1") < 0)
+				Assert.Ignore("This test requires ICU 52 or higher");
+
+			var text = "你是中国人么？ 我喜欢你们的国家。";
+			var locale = new Locale("zh");
+			var expected = new[] {
+				new Boundary(0, 2), new Boundary(2, 5), new Boundary(5, 6), // 你是中国人么
+                new Boundary(8, 9), new Boundary(9, 11), new Boundary(11, 13), // 我喜欢你们
+                new Boundary(13, 14), new Boundary(14, 16) // 的国家
+            };
+
+			using (var bi = BreakIterator.CreateWordInstance(locale, text, includeSpacesAndPunctuation: false))
+			{
+				CollectionAssert.AreEqual(expected, bi.Boundaries);
+
+				int current = 0;
+				var currentBoundary = expected[current];
+				Assert.AreEqual(currentBoundary, bi.Current);
+
+				// Increment the index and verify that the next Boundary is correct.
+				current++;
+				currentBoundary = expected[current];
+				Assert.AreEqual(currentBoundary, bi.Next);
+				Assert.AreEqual(currentBoundary, bi.Current);
+
+				current++;
+				currentBoundary = expected[current];
+				Assert.AreEqual(currentBoundary, bi.Next);
+				Assert.AreEqual(currentBoundary, bi.Current);
+
+				current--;
+				currentBoundary = expected[current];
+				Assert.AreEqual(currentBoundary, bi.Previous);
+				Assert.AreEqual(currentBoundary, bi.Current);
+
+				current--;
+				currentBoundary = expected[current];
+				Assert.AreEqual(currentBoundary, bi.Previous);
+				Assert.AreEqual(currentBoundary, bi.Current);
+
+				// We've moved past the first word, it should return null.
+				Assert.Null(bi.Previous);
+				Assert.Null(bi.Current);
+
+				// Verify that the element is correct now that we've moved to the end.
+				var last = expected.Last();
+				Assert.AreEqual(last, bi.Last);
+				Assert.AreEqual(last, bi.Current);
+			}
+		}
+
+		[Test]
+		public void CanSetNewText()
+		{
+			var locale = new Locale("zh");
+			var text = "Good-day, kind sir !  Can I have a glass of water?  I am very parched.";
+			var expected = new[] { new Boundary(0, 22), new Boundary(22, 52), new Boundary(52, 70) };
+
+			var secondText = "供重呼車遊踏持図質腰大野明会掲歌? 方図強候準素能物第毎止田作昼野集。霊一起続時筑腺算掲断詳山住死示流投。";
+			var secondExpected = new[] { new Boundary(0, 18), new Boundary(18, 35), new Boundary(35, 53) };
+
+			using (var bi = BreakIterator.CreateSentenceInstance(locale, text))
+			{
+				Assert.AreEqual(text, bi.Text);
+				CollectionAssert.AreEqual(expected, bi.Boundaries);
+
+				// Move the iterator to the next boundary
+				Assert.AreEqual(expected[1], bi.Next);
+				Assert.AreEqual(expected[1], bi.Current);
+
+				// Assert that the new set of boundaries were found.
+				bi.SetText(secondText);
+				Assert.AreEqual(secondText, bi.Text);
+
+				// Assert that the iterator was reset back to the first element
+				// when we set new text.
+				Assert.AreEqual(secondExpected[0], bi.Current);
+
+				CollectionAssert.AreEqual(secondExpected, bi.Boundaries);
+			}
+		}
+
 	}
 }

--- a/source/icu.net.tests/BreakIteratorTests.Chinese.cs
+++ b/source/icu.net.tests/BreakIteratorTests.Chinese.cs
@@ -75,8 +75,10 @@ namespace Icu.Tests
 				ideographic, ideographic, ideographic, none
 			};
 
-			using (var bi = BreakIterator.CreateWordInstance(locale, text))
+			using (var bi = BreakIterator.CreateWordInstance(locale))
 			{
+				bi.SetText(text);
+
 				Assert.AreEqual(text, bi.Text);
 				Assert.AreEqual(locale, bi.Locale);
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
@@ -119,8 +121,10 @@ namespace Icu.Tests
 			var locale = new Locale("zh");
 			var expected = new[] { 0, 18, 35, 53 };
 
-			using (var bi = BreakIterator.CreateSentenceInstance(locale, text))
+			using (var bi = BreakIterator.CreateSentenceInstance(locale))
 			{
+				bi.SetText(text);
+
 				Assert.AreEqual(locale, bi.Locale);
 				Assert.AreEqual(text, bi.Text);
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
@@ -147,14 +151,16 @@ namespace Icu.Tests
 				switch (type)
 				{
 					case BreakIterator.UBreakIteratorType.SENTENCE:
-						bi = BreakIterator.CreateSentenceInstance(locale, text);
+						bi = BreakIterator.CreateSentenceInstance(locale);
 						break;
 					case BreakIterator.UBreakIteratorType.WORD:
-						bi = BreakIterator.CreateWordInstance(locale, text);
+						bi = BreakIterator.CreateWordInstance(locale);
 						break;
 					default:
 						throw new NotSupportedException("This iterator type is not supported in this test yet. [" + type + "]");
 				}
+
+				bi.SetText(text);
 
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
 
@@ -231,14 +237,16 @@ namespace Icu.Tests
 				switch (type)
 				{
 					case BreakIterator.UBreakIteratorType.SENTENCE:
-						bi = BreakIterator.CreateSentenceInstance(locale, text);
+						bi = BreakIterator.CreateSentenceInstance(locale);
 						break;
 					case BreakIterator.UBreakIteratorType.WORD:
-						bi = BreakIterator.CreateWordInstance(locale, text);
+						bi = BreakIterator.CreateWordInstance(locale);
 						break;
 					default:
 						throw new NotSupportedException("This iterator type is not supported in this test yet. [" + type + "]");
 				}
+
+				bi.SetText(text);
 
 				for (int i = 0; i < offsetsToTest.Length; i++)
 				{
@@ -277,8 +285,10 @@ namespace Icu.Tests
 				ideographic, ideographic, ideographic, none
 			};
 
-			using (var bi = BreakIterator.CreateWordInstance(locale, text))
+			using (var bi = BreakIterator.CreateWordInstance(locale))
 			{
+				bi.SetText(text);
+
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
 
 				int current = 0;
@@ -349,8 +359,10 @@ namespace Icu.Tests
 			var secondText = "供重呼車遊踏持図質腰大野明会掲歌? 方図強候準素能物第毎止田作昼野集。霊一起続時筑腺算掲断詳山住死示流投。";
 			var secondExpected = new[] { 0, 18, 35, 53 };
 
-			using (var bi = BreakIterator.CreateSentenceInstance(locale, text))
+			using (var bi = BreakIterator.CreateSentenceInstance(locale))
 			{
+				bi.SetText(text);
+
 				Assert.AreEqual(text, bi.Text);
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
 

--- a/source/icu.net.tests/BreakIteratorTests.Chinese.cs
+++ b/source/icu.net.tests/BreakIteratorTests.Chinese.cs
@@ -180,6 +180,59 @@ namespace Icu.Tests
 		}
 
 		[Test]
+		[TestCase(
+			BreakIterator.UBreakIteratorType.SENTENCE,
+			"供重呼車遊踏持図質腰大野明会掲歌? 方図強候準素能物第毎止田作昼野集。霊一起続時筑腺算掲断詳山住死示流投。",
+			new[] { -1, 35, 17, 54, 0, 53, 30, 27 },
+			new[] { false, true, false, false, true, true, false, false },
+			new[] { 0, 35, 18, 53, 0, 53, 35, 35 })]
+		[TestCase(
+			BreakIterator.UBreakIteratorType.WORD,
+			"你是中国人么？ 我喜欢你们的国家。",
+			new[] { 12, 18, 0, 6, -10 },
+			new[] { false, false, true, true, false },
+			new[] { 13, 17, 0, 6, 0 })]
+		public void IsBoundary(BreakIterator.UBreakIteratorType type,
+			string text, 
+			int[] offsetsToTest, 
+			bool[] expectedIsBoundary, 
+			int[] expectedOffsets) // expected BreakIterator.Current after calling IsBoundary.
+		{
+			var locale = new Locale("zh");
+
+			BreakIterator bi = default(BreakIterator);
+
+			try
+			{
+				switch (type)
+				{
+					case BreakIterator.UBreakIteratorType.SENTENCE:
+						bi = BreakIterator.CreateSentenceInstance(locale, text);
+						break;
+					case BreakIterator.UBreakIteratorType.WORD:
+						bi = BreakIterator.CreateWordInstance(locale, text);
+						break;
+					default:
+						throw new NotSupportedException("This iterator type is not supported in this test yet. [" + type + "]");
+				}
+
+				for (int i = 0; i < offsetsToTest.Length; i++)
+				{
+					var isBoundary = bi.IsBoundary(offsetsToTest[i]);
+
+					Assert.AreEqual(expectedIsBoundary[i], isBoundary, "Expected IsBoundary was not equal at i: {0}, offset: {1}", i, offsetsToTest[i]);
+					Assert.AreEqual(expectedOffsets[i], bi.Current);
+				}
+
+			}
+			finally
+			{
+				if (bi != default(BreakIterator))
+					bi.Dispose();
+			}
+		}
+
+		[Test]
 		public void CanIterateBackwards()
 		{
 			if (string.CompareOrdinal(Wrapper.IcuVersion, "52.1") < 0)

--- a/source/icu.net.tests/BreakIteratorTests.Chinese.cs
+++ b/source/icu.net.tests/BreakIteratorTests.Chinese.cs
@@ -90,12 +90,25 @@ namespace Icu.Tests
 					Assert.AreEqual(expected[i], current);
 					Assert.AreEqual(ruleStatus[i], status);
 
-					bi.MoveNext();
+					int moveNext = bi.MoveNext();
+					int next = i + 1;
+
+					if (next < expected.Length)
+					{
+						Assert.AreEqual(expected[next], moveNext);
+					}
+					else
+					{
+						// Verify that the BreakIterator is exhausted because we've
+						// moved past every item.
+						Assert.AreEqual(BreakIterator.DONE, moveNext);
+					}
 				}
 
 				// Verify that the BreakIterator is exhausted because we've
-				// moved past every item.
-				Assert.AreEqual(BreakIterator.DONE, bi.Current);
+				// moved past every item, so current should be the last offset.
+				int lastIndex = expected.Length - 1;
+				Assert.AreEqual(expected[lastIndex], bi.Current);
 			}
 		}
 
@@ -157,16 +170,27 @@ namespace Icu.Tests
 					Assert.AreEqual(expectedStatus, status);
 					CollectionAssert.AreEqual(new[] { expectedStatus }, bi.GetRuleStatusVector());
 
-					bi.MoveNext();
+					int moveNext = bi.MoveNext();
+					int next = i + 1;
+
+					if (next < expected.Length)
+					{
+						Assert.AreEqual(expected[next], moveNext);
+					}
+					else
+					{
+						// Verify that the BreakIterator is exhausted because we've
+						// moved past every item.
+						Assert.AreEqual(BreakIterator.DONE, moveNext);
+					}
 				}
 
-				// Verify that the BreakIterator is exhausted because we've
-				// moved past every item.
-				Assert.AreEqual(BreakIterator.DONE, bi.Current);
+				int lastIndex = expected.Length - 1;
+				Assert.AreEqual(expected[lastIndex], bi.Current);
 
-				// And if we try to move again, it'll return DONE.
+				// We've moved past the last word, it should return the last offset.
 				Assert.AreEqual(BreakIterator.DONE, bi.MoveNext());
-				Assert.AreEqual(BreakIterator.DONE, bi.Current);
+				Assert.AreEqual(expected[lastIndex], bi.Current);
 
 				// Verify that the first element is correct now that we've moved to the end.
 				Assert.AreEqual(expected[0], bi.MoveFirst());
@@ -298,9 +322,9 @@ namespace Icu.Tests
 				Assert.AreEqual(currentStatus, bi.GetRuleStatus());
 				CollectionAssert.AreEqual(new[] { currentStatus }, bi.GetRuleStatusVector());
 
-				// We've moved past the first word, it should return null.
+				// We've moved past the first word, it should return 0.
 				Assert.AreEqual(BreakIterator.DONE, bi.MovePrevious());
-				Assert.AreEqual(BreakIterator.DONE, bi.Current);
+				Assert.AreEqual(0, bi.Current);
 				Assert.AreEqual(0, bi.GetRuleStatus()); // this by default returns 0.
 				CollectionAssert.AreEqual(new[] { 0 }, bi.GetRuleStatusVector()); // default returns 0 in the status vector
 

--- a/source/icu.net.tests/BreakIteratorTests.Chinese.cs
+++ b/source/icu.net.tests/BreakIteratorTests.Chinese.cs
@@ -130,20 +130,20 @@ namespace Icu.Tests
 				// increment the index and verify that the next Boundary is correct.
 				current++;
 				currentBoundary = expected[current];
-				Assert.AreEqual(currentBoundary, bi.Next);
+				Assert.AreEqual(currentBoundary, bi.MoveNext());
 				Assert.AreEqual(currentBoundary, bi.Current);
 
 				current++;
 				currentBoundary = expected[current];
-				Assert.AreEqual(currentBoundary, bi.Next);
+				Assert.AreEqual(currentBoundary, bi.MoveNext());
 				Assert.AreEqual(currentBoundary, bi.Current);
 
 				// We've moved past the last word, it should return null.
-				Assert.Null(bi.Next);
+				Assert.Null(bi.MoveNext());
 				Assert.Null(bi.Current);
 
 				// Verify that the first element is correct now that we've moved to the end.
-				Assert.AreEqual(expected[0], bi.First);
+				Assert.AreEqual(expected[0], bi.MoveFirst());
 				Assert.AreEqual(expected[0], bi.Current);
 			}
 		}
@@ -173,31 +173,31 @@ namespace Icu.Tests
 				// Increment the index and verify that the next Boundary is correct.
 				current++;
 				currentBoundary = expected[current];
-				Assert.AreEqual(currentBoundary, bi.Next);
+				Assert.AreEqual(currentBoundary, bi.MoveNext());
 				Assert.AreEqual(currentBoundary, bi.Current);
 
 				current++;
 				currentBoundary = expected[current];
-				Assert.AreEqual(currentBoundary, bi.Next);
+				Assert.AreEqual(currentBoundary, bi.MoveNext());
 				Assert.AreEqual(currentBoundary, bi.Current);
 
 				current--;
 				currentBoundary = expected[current];
-				Assert.AreEqual(currentBoundary, bi.Previous);
+				Assert.AreEqual(currentBoundary, bi.MovePrevious());
 				Assert.AreEqual(currentBoundary, bi.Current);
 
 				current--;
 				currentBoundary = expected[current];
-				Assert.AreEqual(currentBoundary, bi.Previous);
+				Assert.AreEqual(currentBoundary, bi.MovePrevious());
 				Assert.AreEqual(currentBoundary, bi.Current);
 
 				// We've moved past the first word, it should return null.
-				Assert.Null(bi.Previous);
+				Assert.Null(bi.MovePrevious());
 				Assert.Null(bi.Current);
 
 				// Verify that the element is correct now that we've moved to the end.
 				var last = expected.Last();
-				Assert.AreEqual(last, bi.Last);
+				Assert.AreEqual(last, bi.MoveLast());
 				Assert.AreEqual(last, bi.Current);
 			}
 		}
@@ -218,7 +218,7 @@ namespace Icu.Tests
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
 
 				// Move the iterator to the next boundary
-				Assert.AreEqual(expected[1], bi.Next);
+				Assert.AreEqual(expected[1], bi.MoveNext());
 				Assert.AreEqual(expected[1], bi.Current);
 
 				// Assert that the new set of boundaries were found.

--- a/source/icu.net.tests/BreakIteratorTests.Chinese.cs
+++ b/source/icu.net.tests/BreakIteratorTests.Chinese.cs
@@ -1,5 +1,5 @@
-﻿using NUnit.Framework;
-using System.Linq;
+﻿using System.Linq;
+using NUnit.Framework;
 
 namespace Icu.Tests
 {

--- a/source/icu.net.tests/BreakIteratorTests.Chinese.cs
+++ b/source/icu.net.tests/BreakIteratorTests.Chinese.cs
@@ -151,8 +151,11 @@ namespace Icu.Tests
 					int current = bi.Current;
 					int status = bi.GetRuleStatus();
 
+					int expectedStatus = (int)ruleStatus[i];
+
 					Assert.AreEqual(expected[i], current);
-					Assert.AreEqual((int)ruleStatus[i], status);
+					Assert.AreEqual(expectedStatus, status);
+					CollectionAssert.AreEqual(new[] { expectedStatus }, bi.GetRuleStatusVector());
 
 					bi.MoveNext();
 				}
@@ -206,6 +209,8 @@ namespace Icu.Tests
 				var currentStatus = ruleStatus[current];
 				Assert.AreEqual(currentBoundary, bi.Current);
 				Assert.AreEqual(currentStatus, bi.GetRuleStatus());
+				// For these, we only expect one rule to be applied in order to find the text boundary.
+				CollectionAssert.AreEqual(new[] { currentStatus }, bi.GetRuleStatusVector());
 
 				// Increment the index and verify that the next Boundary is correct.
 				current++;
@@ -214,6 +219,7 @@ namespace Icu.Tests
 				Assert.AreEqual(currentBoundary, bi.MoveNext());
 				Assert.AreEqual(currentBoundary, bi.Current);
 				Assert.AreEqual(currentStatus, bi.GetRuleStatus());
+				CollectionAssert.AreEqual(new[] { currentStatus }, bi.GetRuleStatusVector());
 
 				current++;
 				currentBoundary = expected[current];
@@ -221,6 +227,7 @@ namespace Icu.Tests
 				Assert.AreEqual(currentBoundary, bi.MoveNext());
 				Assert.AreEqual(currentBoundary, bi.Current);
 				Assert.AreEqual(currentStatus, bi.GetRuleStatus());
+				CollectionAssert.AreEqual(new[] { currentStatus }, bi.GetRuleStatusVector());
 
 				current--;
 				currentBoundary = expected[current];
@@ -228,6 +235,7 @@ namespace Icu.Tests
 				Assert.AreEqual(currentBoundary, bi.MovePrevious());
 				Assert.AreEqual(currentBoundary, bi.Current);
 				Assert.AreEqual(currentStatus, bi.GetRuleStatus());
+				CollectionAssert.AreEqual(new[] { currentStatus }, bi.GetRuleStatusVector());
 
 				current--;
 				currentBoundary = expected[current];
@@ -235,16 +243,22 @@ namespace Icu.Tests
 				Assert.AreEqual(currentBoundary, bi.MovePrevious());
 				Assert.AreEqual(currentBoundary, bi.Current);
 				Assert.AreEqual(currentStatus, bi.GetRuleStatus());
+				CollectionAssert.AreEqual(new[] { currentStatus }, bi.GetRuleStatusVector());
 
 				// We've moved past the first word, it should return null.
 				Assert.AreEqual(BreakIterator.DONE, bi.MovePrevious());
 				Assert.AreEqual(BreakIterator.DONE, bi.Current);
 				Assert.AreEqual(0, bi.GetRuleStatus()); // this by default returns 0.
+				CollectionAssert.AreEqual(new[] { 0 }, bi.GetRuleStatusVector()); // default returns 0 in the status vector
 
 				// Verify that the element is correct now that we've moved to the end.
 				var last = expected.Last();
+				var lastStatus = ruleStatus.Last();
+
 				Assert.AreEqual(last, bi.MoveLast());
 				Assert.AreEqual(last, bi.Current);
+				Assert.AreEqual(lastStatus, bi.GetRuleStatus());
+				CollectionAssert.AreEqual(new[] { lastStatus }, bi.GetRuleStatusVector());
 			}
 		}
 
@@ -279,6 +293,5 @@ namespace Icu.Tests
 				CollectionAssert.AreEqual(secondExpected, bi.Boundaries);
 			}
 		}
-
 	}
 }

--- a/source/icu.net.tests/BreakIteratorTests.JDKCompatibility.cs
+++ b/source/icu.net.tests/BreakIteratorTests.JDKCompatibility.cs
@@ -10,6 +10,9 @@ namespace Icu.Tests
     /// </summary>
     [TestFixture]
     [Category("Full ICU")]
+	[Ignore("Ignore tests until a JavaBreakIterator using RuleBasedBreakIterator is written. The rules for JavaBreakIterator can be found at:\n" 
+		+ "http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/7u40-b43/sun/text/resources/BreakIteratorRules.java/ \n" 
+		+ "and http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/7u40-b43/sun/text/resources/BreakIteratorRules_th.java#BreakIteratorRules_th")]
     public class BreakIteratorTests_JDKCompatibility
     {
         static readonly String TEXT =

--- a/source/icu.net.tests/BreakIteratorTests.JDKCompatibility.cs
+++ b/source/icu.net.tests/BreakIteratorTests.JDKCompatibility.cs
@@ -17,7 +17,7 @@ namespace Icu.Tests
 
         private BreakIterator GetWordInstance(System.Globalization.CultureInfo locale)
         {
-            return BreakIterator.CreateWordInstance(new Locale(locale.Name), string.Empty);
+            return BreakIterator.CreateWordInstance(new Locale(locale.Name));
         }
 
         [Test]
@@ -175,7 +175,7 @@ namespace Icu.Tests
 
         private BreakIterator GetSentenceInstance(System.Globalization.CultureInfo locale)
         {
-            return BreakIterator.CreateSentenceInstance(new Locale(locale.Name), string.Empty);
+            return BreakIterator.CreateSentenceInstance(new Locale(locale.Name));
         }
 
         [Test]
@@ -256,8 +256,8 @@ namespace Icu.Tests
 
         private BreakIterator GetLineInstance(System.Globalization.CultureInfo locale)
         {
-            return BreakIterator.CreateLineInstance(new Locale(locale.Name), string.Empty);
-        }
+			return BreakIterator.CreateLineInstance(new Locale(locale.Name));
+		}
 
         [Test]
         public void TestLineIteration()

--- a/source/icu.net.tests/BreakIteratorTests.cs
+++ b/source/icu.net.tests/BreakIteratorTests.cs
@@ -565,7 +565,6 @@ namespace Icu.Tests
 		public void MoveFollowingTest(int offset, int expectedOffset, int expectedCurrent)
 		{
 			var locale = new Locale("de-DE");
-			var expected = new[] { 0, 22, 52, 70 };
 			var text = "Good-day, kind sir !  Can I have a glass of water?  I am very parched.";
 
 			using (var bi = BreakIterator.CreateSentenceInstance(locale))
@@ -586,7 +585,6 @@ namespace Icu.Tests
 		public void MoveFollowingTest_Empty(int offset, int expectedOffset, int expectedCurrent)
 		{
 			var locale = new Locale("de-DE");
-			var expected = new[] { 0, 22, 52, 70 };
 
 			using (var bi = BreakIterator.CreateSentenceInstance(locale))
 			{
@@ -610,7 +608,6 @@ namespace Icu.Tests
 		{
 			var text = "Good-day, kind sir !";
 			var locale = new Locale("de-DE");
-			var expected = new int[] { 0, 4, 5, 8, 9, 10, 14, 15, 18, 19, 20 };
 
 			using (var bi = BreakIterator.CreateWordInstance(locale))
 			{
@@ -630,7 +627,6 @@ namespace Icu.Tests
 		public void MovePrecedingTest_Empty(int offset, int expectedOffset, int expectedCurrent)
 		{
 			var locale = new Locale("de-DE");
-			var expected = new int[] { 0, 4, 5, 8, 9, 10, 14, 15, 18, 19, 20 };
 
 			using (var bi = BreakIterator.CreateWordInstance(locale))
 			{

--- a/source/icu.net.tests/BreakIteratorTests.cs
+++ b/source/icu.net.tests/BreakIteratorTests.cs
@@ -175,10 +175,10 @@ namespace Icu.Tests
 				Assert.AreEqual(0, iterator.Boundaries.Length);
 
 				Assert.Null(iterator.Current);
-				Assert.Null(iterator.Next);
-				Assert.Null(iterator.First);
-				Assert.Null(iterator.Last);
-				Assert.Null(iterator.Previous);
+				Assert.Null(iterator.MoveNext());
+				Assert.Null(iterator.MoveFirst());
+				Assert.Null(iterator.MoveLast());
+				Assert.Null(iterator.MovePrevious());
 			};
 
 			using (var bi = BreakIterator.CreateCharacterInstance(locale, string.Empty))
@@ -212,25 +212,25 @@ namespace Icu.Tests
 				// increment the index and verify that the next Boundary is correct.
 				current++;
 				currentBoundary = expected[current];
-				Assert.AreEqual(currentBoundary, bi.Next);
+				Assert.AreEqual(currentBoundary, bi.MoveNext());
 				Assert.AreEqual(currentBoundary, bi.Current);
 
 				current++;
 				currentBoundary = expected[current];
-				Assert.AreEqual(currentBoundary, bi.Next);
+				Assert.AreEqual(currentBoundary, bi.MoveNext());
 				Assert.AreEqual(currentBoundary, bi.Current);
 
 				current++;
 				currentBoundary = expected[current];
-				Assert.AreEqual(currentBoundary, bi.Next);
+				Assert.AreEqual(currentBoundary, bi.MoveNext());
 				Assert.AreEqual(currentBoundary, bi.Current);
 
 				// We've moved past the last word, it should return null.
-				Assert.Null(bi.Next);
+				Assert.Null(bi.MoveNext());
 				Assert.Null(bi.Current);
 
 				// Verify that the first element is correct now that we've moved to the end.
-				Assert.AreEqual(expected[0], bi.First);
+				Assert.AreEqual(expected[0], bi.MoveFirst());
 				Assert.AreEqual(expected[0], bi.Current);
 			}
 		}
@@ -255,30 +255,30 @@ namespace Icu.Tests
 				// Increment the index and verify that the next Boundary is correct.
 				current++;
 				currentBoundary = expected[current];
-				Assert.AreEqual(currentBoundary, bi.Next);
+				Assert.AreEqual(currentBoundary, bi.MoveNext());
 				Assert.AreEqual(currentBoundary, bi.Current);
 
 				current++;
 				currentBoundary = expected[current];
-				Assert.AreEqual(currentBoundary, bi.Next);
+				Assert.AreEqual(currentBoundary, bi.MoveNext());
 				Assert.AreEqual(currentBoundary, bi.Current);
 
 				current--;
 				currentBoundary = expected[current];
-				Assert.AreEqual(currentBoundary, bi.Previous);
+				Assert.AreEqual(currentBoundary, bi.MovePrevious());
 				Assert.AreEqual(currentBoundary, bi.Current);
 
 				current--;
 				currentBoundary = expected[current];
-				Assert.AreEqual(currentBoundary, bi.Previous);
+				Assert.AreEqual(currentBoundary, bi.MovePrevious());
 				Assert.AreEqual(currentBoundary, bi.Current);
 
 				// We've moved past the first word, it should return null.
-				Assert.Null(bi.Previous);
+				Assert.Null(bi.MovePrevious());
 				Assert.Null(bi.Current);
 
 				// Verify that the element is correct now that we've moved to the end.
-				Assert.AreEqual(expected[3], bi.Last);
+				Assert.AreEqual(expected[3], bi.MoveLast());
 				Assert.AreEqual(expected[3], bi.Current);
 			}
 		}
@@ -299,7 +299,7 @@ namespace Icu.Tests
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
 
 				// Move the iterator to the next boundary
-				Assert.AreEqual(expected[1], bi.Next);
+				Assert.AreEqual(expected[1], bi.MoveNext());
 				Assert.AreEqual(expected[1], bi.Current);
 
 				// Assert that the new set of boundaries were found.
@@ -332,7 +332,7 @@ namespace Icu.Tests
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
 
 				// Move the iterator to the next boundary
-				Assert.AreEqual(expected[1], bi.Next);
+				Assert.AreEqual(expected[1], bi.MoveNext());
 				Assert.AreEqual(expected[1], bi.Current);
 
 				// Assert that the new set of boundaries were found.
@@ -342,10 +342,10 @@ namespace Icu.Tests
 				// Assert that the iterator was reset back to the first element
 				// and is now null.
 				Assert.Null(bi.Current);
-				Assert.Null(bi.Next);
-				Assert.Null(bi.First);
-				Assert.Null(bi.Last);
-				Assert.Null(bi.Previous);
+				Assert.Null(bi.MoveNext());
+				Assert.Null(bi.MoveFirst());
+				Assert.Null(bi.MoveLast());
+				Assert.Null(bi.MovePrevious());
 
 				CollectionAssert.IsEmpty(bi.Boundaries);
 			}
@@ -369,7 +369,7 @@ namespace Icu.Tests
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
 
 				// Move the iterator to the next boundary
-				Assert.AreEqual(expected[1], bi.Next);
+				Assert.AreEqual(expected[1], bi.MoveNext());
 				Assert.AreEqual(expected[1], bi.Current);
 
 				// Assert that the new set of boundaries were found.
@@ -379,10 +379,10 @@ namespace Icu.Tests
 				// Assert that the iterator was reset back to the first element
 				// and is now null.
 				Assert.Null(bi.Current);
-				Assert.Null(bi.Next);
-				Assert.Null(bi.First);
-				Assert.Null(bi.Last);
-				Assert.Null(bi.Previous);
+				Assert.Null(bi.MoveNext());
+				Assert.Null(bi.MoveFirst());
+				Assert.Null(bi.MoveLast());
+				Assert.Null(bi.MovePrevious());
 
 				CollectionAssert.IsEmpty(bi.Boundaries);
 			}

--- a/source/icu.net.tests/BreakIteratorTests.cs
+++ b/source/icu.net.tests/BreakIteratorTests.cs
@@ -159,27 +159,39 @@ namespace Icu.Tests
 					int status = bi.GetRuleStatus();
 
 					Assert.AreEqual(expected[i], current);
-					Assert.AreEqual((int)BreakIterator.UWordBreak.NONE, status);
+					Assert.AreEqual(0, status);
 
-					bi.MoveNext();
+					int moveNext = bi.MoveNext();
+					int next = i + 1;
+
+					if (next < expected.Length)
+					{
+						Assert.AreEqual(expected[next], moveNext);
+					}
+					else
+					{
+						// Verify that the BreakIterator is exhausted because we've
+						// moved past every item.
+						Assert.AreEqual(BreakIterator.DONE, moveNext);
+					}
 				}
 
 				// Verify that the BreakIterator is exhausted because we've
-				// moved past every item.
-				Assert.AreEqual(BreakIterator.DONE, bi.Current);
+				// moved past every item, so current should be the last offset.
+				int lastIndex = expected.Length - 1;
+				Assert.AreEqual(expected[lastIndex], bi.Current);
 			}
 		}
 
 		/// <summary>
-		/// Checking that when a break iterator is created with null or ""
-		/// that it returns the correct properties.
+		/// Checking that when a break iterator is created with "", that it
+		/// returns the correct properties.
 		/// </summary>
 		[Test]
-		[TestCase("")]
-		[TestCase(null)]
-		public void BreakIteratorThatIsEmptyOrNull(string text)
+		public void BreakIteratorThatIsEmpty()
 		{
 			var locale = new Locale("de-DE");
+			string text = string.Empty;
 
 			using (var bi = BreakIterator.CreateCharacterInstance(locale, text))
 			{
@@ -187,17 +199,33 @@ namespace Icu.Tests
 				Assert.AreEqual(text, bi.Text);
 				Assert.AreEqual(0, bi.Boundaries.Length);
 
-				Assert.AreEqual(BreakIterator.DONE, bi.Current);
+				Assert.AreEqual(0, bi.Current);
 				Assert.AreEqual(BreakIterator.DONE, bi.MoveNext());
-				Assert.AreEqual(BreakIterator.DONE, bi.MoveFirst());
-				Assert.AreEqual(BreakIterator.DONE, bi.MoveLast());
+				Assert.AreEqual(0, bi.MoveFirst());
+				Assert.AreEqual(0, bi.MoveLast());
 				Assert.AreEqual(BreakIterator.DONE, bi.MovePrevious());
 
 				// Default value is 0 when there was no rule applied.
-				Assert.AreEqual((int)BreakIterator.UWordBreak.NONE, bi.GetRuleStatus());
+				Assert.AreEqual(0, bi.GetRuleStatus());
 				// When iterator is at DONE, it returns the default rule status vector.
 				CollectionAssert.AreEqual(new[] { 0 }, bi.GetRuleStatusVector());
 			}
+		}
+
+		/// <summary>
+		/// Checking that when a break iterator is created with null that it
+		/// throws an ArgumentNullException.
+		/// </summary>
+		[Test]
+		public void BreakIteratorThatIsNull()
+		{
+			var locale = new Locale("de-DE");
+			string text = null;
+
+			Assert.Throws<ArgumentNullException>(() =>
+			{
+				var bi = BreakIterator.CreateCharacterInstance(locale, text);
+			});
 		}
 
 		[Test]
@@ -228,16 +256,29 @@ namespace Icu.Tests
 					Assert.AreEqual(1, ruleStatusVector.Length);
 					Assert.AreEqual((int)ruleStatus[i], ruleStatusVector[0]);
 
-					bi.MoveNext();
+					int moveNext = bi.MoveNext();
+					int next = i + 1;
+
+					if (next < expected.Length)
+					{
+						Assert.AreEqual(expected[next], moveNext);
+					}
+					else
+					{
+						// Verify that the BreakIterator is exhausted because we've
+						// moved past every item.
+						Assert.AreEqual(BreakIterator.DONE, moveNext);
+					}
 				}
 
 				// Verify that the BreakIterator is exhausted because we've
-				// moved past every item.
-				Assert.AreEqual(BreakIterator.DONE, bi.Current);
+				// moved past every item. It should return the last offset found.
+				int lastIndex = expected.Length - 1;
+				Assert.AreEqual(expected[lastIndex], bi.Current);
 
-				// We've moved past the last word, it should return null.
+				// We've moved past the last word, it should return the last offset.
 				Assert.AreEqual(BreakIterator.DONE, bi.MoveNext());
-				Assert.AreEqual(BreakIterator.DONE, bi.Current);
+				Assert.AreEqual(expected[lastIndex], bi.Current);
 
 				// Verify that the first element is correct now that we've moved to the end.
 				Assert.AreEqual(expected[0], bi.MoveFirst());
@@ -252,7 +293,7 @@ namespace Icu.Tests
 			var text = "Good-day, kind sir !";
 			var expected = new int[] { 0, 5, 10, 15, 20 };
 			// RuleStatus only applies to BreakIterator.UBreakIteratorType.WORD.
-			var expectedStatusRuleVector = new[] { (int)BreakIterator.UWordBreak.NONE };
+			var expectedStatusRuleVector = new[] { 0 };
 			var expectedEmptyRuleStatusVector = new[] { 0 };
 
 			using (var bi = BreakIterator.CreateLineInstance(locale, text))
@@ -263,7 +304,7 @@ namespace Icu.Tests
 				var currentBoundary = expected[current];
 
 				Assert.AreEqual(currentBoundary, bi.Current);
-				Assert.AreEqual((int)BreakIterator.UWordBreak.NONE, bi.GetRuleStatus());
+				Assert.AreEqual(0, bi.GetRuleStatus());
 				CollectionAssert.AreEqual(expectedStatusRuleVector, bi.GetRuleStatusVector());
 
 				// Increment the index and verify that the next Boundary is correct.
@@ -271,14 +312,14 @@ namespace Icu.Tests
 				currentBoundary = expected[current];
 				Assert.AreEqual(currentBoundary, bi.MoveNext());
 				Assert.AreEqual(currentBoundary, bi.Current);
-				Assert.AreEqual((int)BreakIterator.UWordBreak.NONE, bi.GetRuleStatus());
+				Assert.AreEqual(0, bi.GetRuleStatus());
 				CollectionAssert.AreEqual(expectedStatusRuleVector, bi.GetRuleStatusVector());
 
 				current++;
 				currentBoundary = expected[current];
 				Assert.AreEqual(currentBoundary, bi.MoveNext());
 				Assert.AreEqual(currentBoundary, bi.Current);
-				Assert.AreEqual((int)BreakIterator.UWordBreak.NONE, bi.GetRuleStatus());
+				Assert.AreEqual(0, bi.GetRuleStatus());
 				CollectionAssert.AreEqual(expectedStatusRuleVector, bi.GetRuleStatusVector());
 
 				current--;
@@ -291,20 +332,20 @@ namespace Icu.Tests
 				currentBoundary = expected[current];
 				Assert.AreEqual(currentBoundary, bi.MovePrevious());
 				Assert.AreEqual(currentBoundary, bi.Current);
-				Assert.AreEqual((int)BreakIterator.UWordBreak.NONE, bi.GetRuleStatus());
+				Assert.AreEqual(0, bi.GetRuleStatus());
 				CollectionAssert.AreEqual(expectedStatusRuleVector, bi.GetRuleStatusVector());
 
-				// We've moved past the first word, it should return null.
+				// We've moved past the first word, it should return 0.
 				Assert.AreEqual(BreakIterator.DONE, bi.MovePrevious());
-				Assert.AreEqual(BreakIterator.DONE, bi.Current);
-				Assert.AreEqual((int)BreakIterator.UWordBreak.NONE, bi.GetRuleStatus());
+				Assert.AreEqual(0, bi.Current);
+				Assert.AreEqual(0, bi.GetRuleStatus());
 				CollectionAssert.AreEqual(expectedEmptyRuleStatusVector, bi.GetRuleStatusVector());
 
 				// Verify that the element is correct now that we've moved to the end.
 				var last = expected.Last();
 				Assert.AreEqual(last, bi.MoveLast());
 				Assert.AreEqual(last, bi.Current);
-				Assert.AreEqual((int)BreakIterator.UWordBreak.NONE, bi.GetRuleStatus());
+				Assert.AreEqual(0, bi.GetRuleStatus());
 				CollectionAssert.AreEqual(expectedStatusRuleVector, bi.GetRuleStatusVector());
 			}
 		}
@@ -316,7 +357,7 @@ namespace Icu.Tests
 			var text = "Good-day, kind sir !  Can I have a glass of water?  I am very parched.";
 			var expected = new[] { 0, 22, 52, 70 };
 			// RuleStatus only applies to BreakIterator.UBreakIteratorType.WORD.
-			var expectedRuleStatusVector = new[] { (int)BreakIterator.UWordBreak.NONE };
+			var expectedRuleStatusVector = new[] { 0 };
 
 			var secondText = "It is my birthday!  I hope something exciting happens.";
 			var secondExpected = new[] { 0, 20, 54 };
@@ -329,7 +370,7 @@ namespace Icu.Tests
 				// Move the iterator to the next boundary
 				Assert.AreEqual(expected[1], bi.MoveNext());
 				Assert.AreEqual(expected[1], bi.Current);
-				Assert.AreEqual((int)BreakIterator.UWordBreak.NONE, bi.GetRuleStatus());
+				Assert.AreEqual(0, bi.GetRuleStatus());
 				CollectionAssert.AreEqual(expectedRuleStatusVector, bi.GetRuleStatusVector());
 
 				// Assert that the new set of boundaries were found.
@@ -339,7 +380,7 @@ namespace Icu.Tests
 				// Assert that the iterator was reset back to the first element
 				// when we set new text.
 				Assert.AreEqual(secondExpected[0], bi.Current);
-				Assert.AreEqual((int)BreakIterator.UWordBreak.NONE, bi.GetRuleStatus());
+				Assert.AreEqual(0, bi.GetRuleStatus());
 				CollectionAssert.AreEqual(expectedRuleStatusVector, bi.GetRuleStatusVector());
 
 				CollectionAssert.AreEqual(secondExpected, bi.Boundaries);
@@ -350,15 +391,14 @@ namespace Icu.Tests
 		/// Assert that when we set the text to empty that it will reset all the values.
 		/// </summary>
 		[Test]
-		[TestCase("")]
-		[TestCase(null)]
-		public void CanSetNewText_EmptyOrNull(string secondText)
+		public void CanSetNewText_Empty()
 		{
 			var locale = new Locale("en-US");
 			var text = "Good-day, kind sir !  Can I have a glass of water?  I am very parched.";
+			string secondText = string.Empty;
 			var expected = new[] { 0, 22, 52, 70 };
 			// RuleStatus only applies to BreakIterator.UBreakIteratorType.WORD.
-			var expectedRuleStatusVector = new[] { (int)BreakIterator.UWordBreak.NONE };
+			var expectedRuleStatusVector = new[] { 0 };
 
 			using (var bi = BreakIterator.CreateSentenceInstance(locale, text))
 			{
@@ -368,7 +408,7 @@ namespace Icu.Tests
 				// Move the iterator to the next boundary
 				Assert.AreEqual(expected[1], bi.MoveNext());
 				Assert.AreEqual(expected[1], bi.Current);
-				Assert.AreEqual((int)BreakIterator.UWordBreak.NONE, bi.GetRuleStatus());
+				Assert.AreEqual(0, bi.GetRuleStatus());
 				CollectionAssert.AreEqual(expectedRuleStatusVector, bi.GetRuleStatusVector());
 
 				// Assert that the new set of boundaries were found.
@@ -377,15 +417,31 @@ namespace Icu.Tests
 
 				// Assert that the iterator was reset back to the first element
 				// and is now null.
-				Assert.AreEqual(BreakIterator.DONE, bi.Current);
+				Assert.AreEqual(0, bi.Current);
 				Assert.AreEqual(BreakIterator.DONE, bi.MoveNext());
-				Assert.AreEqual(BreakIterator.DONE, bi.MoveFirst());
-				Assert.AreEqual(BreakIterator.DONE, bi.MoveLast());
+				Assert.AreEqual(0, bi.MoveFirst());
+				Assert.AreEqual(0, bi.MoveLast());
 				Assert.AreEqual(BreakIterator.DONE, bi.MovePrevious());
-				Assert.AreEqual((int)BreakIterator.UWordBreak.NONE, bi.GetRuleStatus());
+				Assert.AreEqual(0, bi.GetRuleStatus());
 				Assert.AreEqual(new [] { 0 }, bi.GetRuleStatusVector());
 
 				CollectionAssert.IsEmpty(bi.Boundaries);
+			}
+		}
+
+		/// <summary>
+		/// Assert that when we set the text to null, an ArgumentNullException is thrown.
+		/// </summary>
+		[Test]
+		public void CanSetNewText_Null()
+		{
+			var locale = new Locale("en-US");
+			var text = "Good-day, kind sir !  Can I have a glass of water?  I am very parched.";
+			string secondText = null;
+
+			using (var bi = BreakIterator.CreateCharacterInstance(locale, text))
+			{
+				Assert.Throws<ArgumentNullException>(() => bi.SetText(secondText));
 			}
 		}
 
@@ -435,10 +491,9 @@ namespace Icu.Tests
 		}
 
 		[Test]
-		[TestCase("")]
-		[TestCase(null)]
-		public void IsBoundaryTest_EmptyOrNull(string text)
+		public void IsBoundaryTest_Empty()
 		{
+			string text = string.Empty;
 			var offsetsToTest = new[] { 0, -1, 100 };
 			var locale = new Locale("de-DE");
 
@@ -448,29 +503,29 @@ namespace Icu.Tests
 				{
 					var isBoundary = bi.IsBoundary(offsetsToTest[i]);
 					Assert.IsFalse(isBoundary);
-					Assert.AreEqual(BreakIterator.DONE, bi.Current);
+					Assert.AreEqual(0, bi.Current);
 				}
 			}
 		}
 
 		[Test]
-		public void IsBoundaryTest()
+		[TestCase(-1, false, 0)]
+		[TestCase(21, false, 20)]
+		[TestCase(11, false, 14)]
+		[TestCase(5, true, 5)]
+		[TestCase(0, true, 0)]
+		[TestCase(20, true, 20)]
+		public void IsBoundaryTest(int offset, bool expectedIsBoundary, int expectedOffset)
 		{
 			var locale = new Locale("de-DE");
 			var text = "Good-day, kind sir !";
-			var offsetsToTest = new[] { -1, 21, 11, 5, 0, 20 };
-			var expectedIsBoundary = new[] { false, false, false, true, true, true };
-			var expectedOffsets = new[] { 0, 20, 14, 5, 0, 20 };
 
 			using (var bi = BreakIterator.CreateWordInstance(locale, text))
 			{
-				for (int i = 0; i < offsetsToTest.Length; i++)
-				{
-					var isBoundary = bi.IsBoundary(offsetsToTest[i]);
+				var isBoundary = bi.IsBoundary(offset);
 
-					Assert.AreEqual(expectedIsBoundary[i], isBoundary, "Expected IsBoundary was not equal at i: {0}, offset: {1}", i, offsetsToTest[i]);
-					Assert.AreEqual(expectedOffsets[i], bi.Current);
-				}
+				Assert.AreEqual(expectedIsBoundary, isBoundary);
+				Assert.AreEqual(expectedOffset, bi.Current);
 			}
 		}
 

--- a/source/icu.net.tests/BreakIteratorTests.cs
+++ b/source/icu.net.tests/BreakIteratorTests.cs
@@ -434,6 +434,46 @@ namespace Icu.Tests
 			}
 		}
 
+		[Test]
+		[TestCase("")]
+		[TestCase(null)]
+		public void IsBoundaryTest_EmptyOrNull(string text)
+		{
+			var offsetsToTest = new[] { 0, -1, 100 };
+			var locale = new Locale("de-DE");
+
+			using (var bi = BreakIterator.CreateWordInstance(locale, text))
+			{
+				for (int i = 0; i < offsetsToTest.Length; i++)
+				{
+					var isBoundary = bi.IsBoundary(offsetsToTest[i]);
+					Assert.IsFalse(isBoundary);
+					Assert.AreEqual(BreakIterator.DONE, bi.Current);
+				}
+			}
+		}
+
+		[Test]
+		public void IsBoundaryTest()
+		{
+			var locale = new Locale("de-DE");
+			var text = "Good-day, kind sir !";
+			var offsetsToTest = new[] { -1, 21, 11, 5, 0, 20 };
+			var expectedIsBoundary = new[] { false, false, false, true, true, true };
+			var expectedOffsets = new[] { 0, 20, 14, 5, 0, 20 };
+
+			using (var bi = BreakIterator.CreateWordInstance(locale, text))
+			{
+				for (int i = 0; i < offsetsToTest.Length; i++)
+				{
+					var isBoundary = bi.IsBoundary(offsetsToTest[i]);
+
+					Assert.AreEqual(expectedIsBoundary[i], isBoundary, "Expected IsBoundary was not equal at i: {0}, offset: {1}", i, offsetsToTest[i]);
+					Assert.AreEqual(expectedOffsets[i], bi.Current);
+				}
+			}
+		}
+
 		/// <summary>
 		/// Test data for GetBoundaries_Word and GetWordBoundaries  tests
 		/// </summary>

--- a/source/icu.net.tests/BreakIteratorTests.cs
+++ b/source/icu.net.tests/BreakIteratorTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) 2013 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
-using NUnit.Framework;
 using System;
 using System.Linq;
+using NUnit.Framework;
 
 namespace Icu.Tests
 {

--- a/source/icu.net.tests/BreakIteratorTests.cs
+++ b/source/icu.net.tests/BreakIteratorTests.cs
@@ -1,7 +1,8 @@
-// Copyright (c) 2013 SIL International
+﻿// Copyright (c) 2013 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
-using System.Linq;
 using NUnit.Framework;
+using System;
+using System.Linq;
 
 namespace Icu.Tests
 {
@@ -136,6 +137,90 @@ namespace Icu.Tests
 
 			Assert.That(lineBoundaries.Count(), Is.EqualTo(expectedLines.Length));
 			Assert.That(lineBoundaries.ToArray(), Is.EquivalentTo(expectedLines));
+		}
+
+		[Test]
+		public void CreateChracterInstanceTest()
+		{
+			var locale = new Locale("de-DE");
+			var text = "Good-bye, dear!";
+			var expected = new[] {
+				new Boundary(0, 1), new Boundary(1, 2), new Boundary(2, 3), new Boundary(3, 4),
+				new Boundary(4, 5), new Boundary(5, 6), new Boundary(6, 7), new Boundary(7, 8),
+				new Boundary(8, 9), new Boundary(9, 10), new Boundary(10, 11), new Boundary(11, 12),
+				new Boundary(12, 13), new Boundary(13, 14), new Boundary(14, 15)
+			};
+
+			using (var bi = BreakIterator.CreateCharacterInstance(locale, text))
+			{
+				Assert.AreEqual(locale, bi.Locale);
+				CollectionAssert.AreEqual(expected, bi.Boundaries);
+			}
+		}
+
+		[Test]
+		public void CreateSentenceInstanceTest()
+		{
+			var locale = new Locale("de-DE");
+			var text = "Good-bye, dear! That was a delicious dinner.";
+			var expected = new[] { new Boundary(0, 16), new Boundary(16, 44) };
+
+			using (var bi = BreakIterator.CreateSentenceInstance(locale, text))
+			{
+				Assert.AreEqual(locale, bi.Locale);
+				CollectionAssert.AreEqual(expected, bi.Boundaries);
+			}
+		}
+
+		[Test]
+		public void CreateWordInstanceTest()
+		{
+			var locale = new Locale("de-DE");
+			var text = "Good-day, kind sir !";
+			var expectedWords = new[] {
+				new Boundary(0, 4), new Boundary(5, 8), new Boundary(10, 14), new Boundary(15, 18)
+			};
+
+			using (var bi = BreakIterator.CreateWordInstance(locale, text, includeSpacesAndPunctuation: false))
+			{
+				Assert.AreEqual(locale, bi.Locale);
+				CollectionAssert.AreEqual(expectedWords, bi.Boundaries);
+			}
+		}
+
+		[Test]
+		public void CreateWordInstanceTest_IncludeSpacesAndPunctuation()
+		{
+			var locale = new Locale("de-DE");
+			var text = "Good-day, kind sir !";
+			var expected = new[] {
+				new Boundary(0, 4), new Boundary(4, 5),
+				new Boundary(5, 8), new Boundary(8, 9), new Boundary(9, 10),
+				new Boundary(10, 14), new Boundary(14, 15), new Boundary(15, 18),
+				new Boundary(18, 19), new Boundary(19, 20)
+			};
+
+			using (var bi = BreakIterator.CreateWordInstance(locale, text, includeSpacesAndPunctuation: true))
+			{
+				Assert.AreEqual(locale, bi.Locale);
+				CollectionAssert.AreEqual(expected, bi.Boundaries);
+			}
+		}
+
+		[Test]
+		public void CreateLineInstanceTest()
+		{
+			var locale = new Locale("de-DE");
+			var text = "Good-day, kind sir !";
+			var expected = new[] {
+				new Boundary(0, 5), new Boundary(5, 10), new Boundary(10, 15), new Boundary(15, 20)
+			};
+
+			using (var bi = BreakIterator.CreateLineInstance(locale, text))
+			{
+				Assert.AreEqual(locale, bi.Locale);
+				CollectionAssert.AreEqual(expected, bi.Boundaries);
+			}
 		}
 
 		/// <summary>

--- a/source/icu.net.tests/BreakIteratorTests.cs
+++ b/source/icu.net.tests/BreakIteratorTests.cs
@@ -146,8 +146,10 @@ namespace Icu.Tests
 			var text = "Good-bye, dear!";
 			var expected = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 
-			using (var bi = BreakIterator.CreateCharacterInstance(locale, text))
+			using (var bi = BreakIterator.CreateCharacterInstance(locale))
 			{
+				bi.SetText(text);
+
 				Assert.AreEqual(locale, bi.Locale);
 				Assert.AreEqual(text, bi.Text);
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
@@ -193,8 +195,10 @@ namespace Icu.Tests
 			var locale = new Locale("de-DE");
 			string text = string.Empty;
 
-			using (var bi = BreakIterator.CreateCharacterInstance(locale, text))
+			using (var bi = BreakIterator.CreateCharacterInstance(locale))
 			{
+				bi.SetText(text);
+
 				Assert.AreEqual(locale, bi.Locale);
 				Assert.AreEqual(text, bi.Text);
 				Assert.AreEqual(0, bi.Boundaries.Length);
@@ -220,12 +224,14 @@ namespace Icu.Tests
 		public void BreakIteratorThatIsNull()
 		{
 			var locale = new Locale("de-DE");
-			string text = null;
 
-			Assert.Throws<ArgumentNullException>(() =>
+			using (var bi = BreakIterator.CreateCharacterInstance(locale))
 			{
-				var bi = BreakIterator.CreateCharacterInstance(locale, text);
-			});
+				Assert.Throws<ArgumentNullException>(() =>
+				{
+					bi.SetText(null);
+				});
+			}
 		}
 
 		[Test]
@@ -239,8 +245,10 @@ namespace Icu.Tests
 			var letter = BreakIterator.UWordBreak.LETTER;
 			var ruleStatus = new[] { none, letter, none, letter, none, none, letter, none, letter, none, none };
 
-			using (var bi = BreakIterator.CreateWordInstance(locale, text))
+			using (var bi = BreakIterator.CreateWordInstance(locale))
 			{
+				bi.SetText(text);
+
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
 
 				// Verify each boundary and rule status.
@@ -296,8 +304,10 @@ namespace Icu.Tests
 			var expectedStatusRuleVector = new[] { 0 };
 			var expectedEmptyRuleStatusVector = new[] { 0 };
 
-			using (var bi = BreakIterator.CreateLineInstance(locale, text))
+			using (var bi = BreakIterator.CreateLineInstance(locale))
 			{
+				bi.SetText(text);
+
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
 
 				int current = 0;
@@ -362,8 +372,10 @@ namespace Icu.Tests
 			var secondText = "It is my birthday!  I hope something exciting happens.";
 			var secondExpected = new[] { 0, 20, 54 };
 
-			using (var bi = BreakIterator.CreateSentenceInstance(locale, text))
+			using (var bi = BreakIterator.CreateSentenceInstance(locale))
 			{
+				bi.SetText(text);
+
 				Assert.AreEqual(text, bi.Text);
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
 
@@ -400,8 +412,10 @@ namespace Icu.Tests
 			// RuleStatus only applies to BreakIterator.UBreakIteratorType.WORD.
 			var expectedRuleStatusVector = new[] { 0 };
 
-			using (var bi = BreakIterator.CreateSentenceInstance(locale, text))
+			using (var bi = BreakIterator.CreateSentenceInstance(locale))
 			{
+				bi.SetText(text);
+
 				Assert.AreEqual(text, bi.Text);
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
 
@@ -439,8 +453,10 @@ namespace Icu.Tests
 			var text = "Good-day, kind sir !  Can I have a glass of water?  I am very parched.";
 			string secondText = null;
 
-			using (var bi = BreakIterator.CreateCharacterInstance(locale, text))
+			using (var bi = BreakIterator.CreateCharacterInstance(locale))
 			{
+				bi.SetText(text);
+
 				Assert.Throws<ArgumentNullException>(() => bi.SetText(secondText));
 			}
 		}
@@ -452,8 +468,10 @@ namespace Icu.Tests
 			var text = "Good-bye, dear! That was a delicious dinner.";
 			var expected = new[] { 0, 16, 44 };
 
-			using (var bi = BreakIterator.CreateSentenceInstance(locale, text))
+			using (var bi = BreakIterator.CreateSentenceInstance(locale))
 			{
+				bi.SetText(text);
+
 				Assert.AreEqual(locale, bi.Locale);
 				Assert.AreEqual(text, bi.Text);
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
@@ -467,8 +485,10 @@ namespace Icu.Tests
 			var text = "Good-day, kind sir !";
 			var expected = new int[] { 0, 4, 5, 8, 9, 10, 14, 15, 18, 19, 20 };
 
-			using (var bi = BreakIterator.CreateWordInstance(locale, text))
+			using (var bi = BreakIterator.CreateWordInstance(locale))
 			{
+				bi.SetText(text);
+
 				Assert.AreEqual(locale, bi.Locale);
 				Assert.AreEqual(text, bi.Text);
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
@@ -482,8 +502,10 @@ namespace Icu.Tests
 			var text = "Good-day, kind sir !";
 			var expected = new[] { 0, 5, 10, 15, 20 };
 
-			using (var bi = BreakIterator.CreateLineInstance(locale, text))
+			using (var bi = BreakIterator.CreateLineInstance(locale))
 			{
+				bi.SetText(text);
+
 				Assert.AreEqual(locale, bi.Locale);
 				Assert.AreEqual(text, bi.Text);
 				CollectionAssert.AreEqual(expected, bi.Boundaries);
@@ -497,8 +519,10 @@ namespace Icu.Tests
 			var offsetsToTest = new[] { 0, -1, 100 };
 			var locale = new Locale("de-DE");
 
-			using (var bi = BreakIterator.CreateWordInstance(locale, text))
+			using (var bi = BreakIterator.CreateWordInstance(locale))
 			{
+				bi.SetText(text);
+
 				for (int i = 0; i < offsetsToTest.Length; i++)
 				{
 					var isBoundary = bi.IsBoundary(offsetsToTest[i]);
@@ -520,8 +544,10 @@ namespace Icu.Tests
 			var locale = new Locale("de-DE");
 			var text = "Good-day, kind sir !";
 
-			using (var bi = BreakIterator.CreateWordInstance(locale, text))
+			using (var bi = BreakIterator.CreateWordInstance(locale))
 			{
+				bi.SetText(text);
+
 				var isBoundary = bi.IsBoundary(offset);
 
 				Assert.AreEqual(expectedIsBoundary, isBoundary);
@@ -542,8 +568,10 @@ namespace Icu.Tests
 			var expected = new[] { 0, 22, 52, 70 };
 			var text = "Good-day, kind sir !  Can I have a glass of water?  I am very parched.";
 
-			using (var bi = BreakIterator.CreateSentenceInstance(locale, text))
+			using (var bi = BreakIterator.CreateSentenceInstance(locale))
 			{
+				bi.SetText(text);
+
 				int actualOffset = bi.MoveFollowing(offset);
 
 				Assert.AreEqual(expectedOffset, actualOffset);
@@ -560,8 +588,10 @@ namespace Icu.Tests
 			var locale = new Locale("de-DE");
 			var expected = new[] { 0, 22, 52, 70 };
 
-			using (var bi = BreakIterator.CreateSentenceInstance(locale, string.Empty))
+			using (var bi = BreakIterator.CreateSentenceInstance(locale))
 			{
+				bi.SetText(string.Empty);
+
 				int actualOffset = bi.MoveFollowing(offset);
 
 				Assert.AreEqual(expectedOffset, actualOffset);
@@ -582,8 +612,10 @@ namespace Icu.Tests
 			var locale = new Locale("de-DE");
 			var expected = new int[] { 0, 4, 5, 8, 9, 10, 14, 15, 18, 19, 20 };
 
-			using (var bi = BreakIterator.CreateWordInstance(locale, text))
+			using (var bi = BreakIterator.CreateWordInstance(locale))
 			{
+				bi.SetText(text);
+
 				int actualOffset = bi.MovePreceding(offset);
 
 				Assert.AreEqual(expectedOffset, actualOffset);
@@ -600,8 +632,10 @@ namespace Icu.Tests
 			var locale = new Locale("de-DE");
 			var expected = new int[] { 0, 4, 5, 8, 9, 10, 14, 15, 18, 19, 20 };
 
-			using (var bi = BreakIterator.CreateWordInstance(locale, string.Empty))
+			using (var bi = BreakIterator.CreateWordInstance(locale))
 			{
+				bi.SetText(string.Empty);
+
 				int actualOffset = bi.MovePreceding(offset);
 
 				Assert.AreEqual(expectedOffset, actualOffset);

--- a/source/icu.net.tests/BreakIteratorTests.cs
+++ b/source/icu.net.tests/BreakIteratorTests.cs
@@ -318,50 +318,13 @@ namespace Icu.Tests
 		/// Assert that when we set the text to empty that it will reset all the values.
 		/// </summary>
 		[Test]
-		public void CanSetNewText_Empty()
+		[TestCase("")]
+		[TestCase(null)]
+		public void CanSetNewText_EmptyOrNull(string secondText)
 		{
 			var locale = new Locale("en-US");
 			var text = "Good-day, kind sir !  Can I have a glass of water?  I am very parched.";
 			var expected = new[] { new Boundary(0, 22), new Boundary(22, 52), new Boundary(52, 70) };
-
-			var secondText = string.Empty;
-
-			using (var bi = BreakIterator.CreateSentenceInstance(locale, text))
-			{
-				Assert.AreEqual(text, bi.Text);
-				CollectionAssert.AreEqual(expected, bi.Boundaries);
-
-				// Move the iterator to the next boundary
-				Assert.AreEqual(expected[1], bi.MoveNext());
-				Assert.AreEqual(expected[1], bi.Current);
-
-				// Assert that the new set of boundaries were found.
-				bi.SetText(secondText);
-				Assert.AreEqual(secondText, bi.Text);
-
-				// Assert that the iterator was reset back to the first element
-				// and is now null.
-				Assert.Null(bi.Current);
-				Assert.Null(bi.MoveNext());
-				Assert.Null(bi.MoveFirst());
-				Assert.Null(bi.MoveLast());
-				Assert.Null(bi.MovePrevious());
-
-				CollectionAssert.IsEmpty(bi.Boundaries);
-			}
-		}
-
-		/// <summary>
-		/// Assert that when we set the text to null that it will reset all the values.
-		/// </summary>
-		[Test]
-		public void CanSetNewText_Null()
-		{
-			var locale = new Locale("en-US");
-			var text = "Good-day, kind sir !  Can I have a glass of water?  I am very parched.";
-			var expected = new[] { new Boundary(0, 22), new Boundary(22, 52), new Boundary(52, 70) };
-
-			string secondText = null;
 
 			using (var bi = BreakIterator.CreateSentenceInstance(locale, text))
 			{

--- a/source/icu.net.tests/Collation/CollatorTests.cs
+++ b/source/icu.net.tests/Collation/CollatorTests.cs
@@ -15,7 +15,10 @@ namespace Icu.Tests.Collation
 		//This fails when ICU's data DLL is built without rules for the en locale.
 		public void Create_Locale()
 		{
-			Assert.That(Collator.Create("en"), Is.Not.Null);
+			using (var collator = Collator.Create("en"))
+			{
+				Assert.That(collator, Is.Not.Null);
+			}
 		}
 
 		[Test]
@@ -24,7 +27,10 @@ namespace Icu.Tests.Collation
 		public void Create_LocaleWithCultureInfo()
 		{
 			var cultureInfo = new CultureInfo("en-US");
-			Assert.That(Collator.Create(cultureInfo.Name), Is.Not.Null);
+			using (var collator = Collator.Create(cultureInfo.Name))
+			{
+				Assert.That(collator, Is.Not.Null);
+			}
 		}
 
 		[Test]
@@ -32,7 +38,10 @@ namespace Icu.Tests.Collation
 		//This fails when ICU's data DLL is built without rules for the en-US locale.
 		public void Create_LocaleWithICUCultureId()
 		{
-			Assert.That(Collator.Create("en_US"), Is.Not.Null);
+			using (var collator = Collator.Create("en_US"))
+			{
+				Assert.That(collator, Is.Not.Null);
+			}
 		}
 
 		[Test]
@@ -40,7 +49,10 @@ namespace Icu.Tests.Collation
 		//This fails when ICU's data DLL is built without rules for the root locale.
 		public void Create_RootLocale()
 		{
-			Assert.That(Collator.Create("root"), Is.Not.Null);
+			using (var collator = Collator.Create("root"))
+			{
+				Assert.That(collator, Is.Not.Null);
+			}
 		}
 
 		[Test]
@@ -48,7 +60,10 @@ namespace Icu.Tests.Collation
 		//This fails when ICU's data DLL is built without rules for the root locale.
 		public void Create_RootLocaleAsEmpty()
 		{
-			Assert.That(Collator.Create(string.Empty), Is.Not.Null);
+			using (var collator = Collator.Create(string.Empty))
+			{
+				Assert.That(collator, Is.Not.Null);
+			}
 		}
 
 		[Test]
@@ -60,7 +75,10 @@ namespace Icu.Tests.Collation
 		[Test]
 		public void Create_nonexistentFallbackAllowed_fallsbackToUca()
 		{
-			Assert.That(Collator.Create("non-existent", Collator.Fallback.FallbackAllowed), Is.Not.Null);
+			using (var collator = Collator.Create("non-existent", Collator.Fallback.FallbackAllowed))
+			{
+				Assert.That(collator, Is.Not.Null);
+			}
 		}
 
 		[Test]

--- a/source/icu.net.tests/Collation/RuleBasedCollatorTests.cs
+++ b/source/icu.net.tests/Collation/RuleBasedCollatorTests.cs
@@ -48,13 +48,19 @@ namespace Icu.Tests.Collation
 		[Test]
 		public void Construct_EmptyRules_UCAcollator()
 		{
-			Assert.That(new RuleBasedCollator(string.Empty), Is.Not.Null);
+			using (var collator = new RuleBasedCollator(string.Empty))
+			{
+				Assert.That(collator, Is.Not.Null);
+			}
 		}
 
 		[Test]
 		public void Construct_Rules_Okay()
 		{
-			Assert.That(new RuleBasedCollator(SerbianRules), Is.Not.Null);
+			using (var collator = new RuleBasedCollator(SerbianRules))
+			{
+				Assert.That(collator, Is.Not.Null);
+			}
 		}
 
 		[Test]
@@ -68,9 +74,11 @@ namespace Icu.Tests.Collation
 		[Test]
 		public void Clone()
 		{
-			var danishCollator = new RuleBasedCollator(DanishRules);
-			var danishCollator2 = (RuleBasedCollator) danishCollator.Clone();
-			Assert.That(danishCollator2.Compare("wa", "vb"), Is.EqualTo(-1));
+			using (var danishCollator = new RuleBasedCollator(DanishRules))
+			using (var danishCollator2 = (RuleBasedCollator)danishCollator.Clone())
+			{
+				Assert.That(danishCollator2.Compare("wa", "vb"), Is.EqualTo(-1));
+			}
 		}
 
 		[TestCase("", null, "a", Result = -1)]
@@ -87,36 +95,43 @@ namespace Icu.Tests.Collation
 		[Test]
 		public void GetSortKey()
 		{
-			var serbianCollator = new RuleBasedCollator(SerbianRules);
-			var sortKeyČUKIĆ = serbianCollator.GetSortKey("ČUKIĆ SLOBODAN");
-			var sortKeyCUKIĆ = serbianCollator.GetSortKey("CUKIĆ SVETOZAR");
-			Assert.That(SortKey.Compare(sortKeyČUKIĆ, sortKeyCUKIĆ), Is.EqualTo(1));
+			using (var serbianCollator = new RuleBasedCollator(SerbianRules))
+			{
+				var sortKeyČUKIĆ = serbianCollator.GetSortKey("ČUKIĆ SLOBODAN");
+				var sortKeyCUKIĆ = serbianCollator.GetSortKey("CUKIĆ SVETOZAR");
+				Assert.That(SortKey.Compare(sortKeyČUKIĆ, sortKeyCUKIĆ), Is.EqualTo(1));
+			}
 		}
 
 		[Test]
 		public void GetSortKey_Null()
 		{
-			var ucaCollator = new RuleBasedCollator(string.Empty);
-			Assert.That(() => ucaCollator.GetSortKey(null), Throws.TypeOf<ArgumentNullException>());
+			using (var ucaCollator = new RuleBasedCollator(string.Empty))
+			{
+				Assert.That(() => ucaCollator.GetSortKey(null), Throws.TypeOf<ArgumentNullException>());
+			}
 		}
 
 		[Test]
 		public void GetSortKey_emptyString()
 		{
-			var ucaCollator = new RuleBasedCollator(string.Empty);
-			SortKey key = ucaCollator.GetSortKey(string.Empty);
-			Assert.IsNotNull(key);
-			Assert.IsNotNull(key.KeyData);
+			using (var ucaCollator = new RuleBasedCollator(string.Empty))
+			{
+				SortKey key = ucaCollator.GetSortKey(string.Empty);
+				Assert.IsNotNull(key);
+				Assert.IsNotNull(key.KeyData);
+			}
 		}
 
 		[Test]
 		public void SetCollatorStrengthToIdentical()
 		{
-			var collator = Collator.Create("zh");
+			using (var collator = Collator.Create("zh"))
+			{
+				collator.Strength = CollationStrength.Identical;
 
-			collator.Strength = CollationStrength.Identical;
-
-			Assert.AreEqual(CollationStrength.Identical, collator.Strength);
+				Assert.AreEqual(CollationStrength.Identical, collator.Strength);
+			}
 		}
 
 		[TestCase(CollationStrength.Tertiary, AlternateHandling.Shifted, "di Silva", "diSilva", Result = 0)]
@@ -147,9 +162,11 @@ namespace Icu.Tests.Collation
                   S=3, A=S di Silva = diSilva < Di Silva  < U.S.A. = USA
                   S=4, A=S di Silva < diSilva < Di Silva < U.S.A. < USA
              */
-			var ucaCollator = new RuleBasedCollator(string.Empty, collationStrength);
-			ucaCollator.AlternateHandling = alternateHandling;
-			return ucaCollator.Compare(string1, string2);
+			using (var ucaCollator = new RuleBasedCollator(string.Empty, collationStrength))
+			{
+				ucaCollator.AlternateHandling = alternateHandling;
+				return ucaCollator.Compare(string1, string2);
+			}
 		}
 
 		[TestCase(CaseFirst.LowerFirst, "china", "China", Result = -1)]
@@ -177,10 +194,12 @@ namespace Icu.Tests.Collation
                     C=X or C=L "china" < "China" < "denmark" < "Denmark"
                     C=U "China" < "china" < "Denmark" < "denmark"
              */
-			var ucaCollator = new RuleBasedCollator(string.Empty);
-			ucaCollator.CaseFirst = caseFirst;
-			Assert.That(ucaCollator.CaseFirst, Is.EqualTo(caseFirst));
-			return ucaCollator.Compare(string1, string2);
+			using (var ucaCollator = new RuleBasedCollator(string.Empty))
+			{
+				ucaCollator.CaseFirst = caseFirst;
+				Assert.That(ucaCollator.CaseFirst, Is.EqualTo(caseFirst));
+				return ucaCollator.Compare(string1, string2);
+			}
 		}
 
 		[TestCase(CaseLevel.Off, "role", "Role", Result = 0)]
@@ -196,11 +215,12 @@ namespace Icu.Tests.Collation
                 Example:
                 S=1, E=X role = Role = rôle
                 S=1, E=O role = rôle <  Role*/
-
-			var ucaCollator = new RuleBasedCollator(string.Empty, CollationStrength.Primary);
-			Assert.That(ucaCollator.CaseLevel, Is.EqualTo(CaseLevel.Off));
-			ucaCollator.CaseLevel = caseLevel;
-			return ucaCollator.Compare(string1, string2);
+			using (var ucaCollator = new RuleBasedCollator(string.Empty, CollationStrength.Primary))
+			{
+				Assert.That(ucaCollator.CaseLevel, Is.EqualTo(CaseLevel.Off));
+				ucaCollator.CaseLevel = caseLevel;
+				return ucaCollator.Compare(string1, string2);
+			}
 		}
 
 		[TestCase(FrenchCollation.Off, "cote", "coté", Result = -1)]
@@ -221,10 +241,12 @@ namespace Icu.Tests.Collation
                 F=X cote < coté < côte < côté
                 F=O cote < côte < coté < côté
              */
-			var ucaCollator = new RuleBasedCollator(string.Empty);
-			Assert.That(ucaCollator.FrenchCollation, Is.EqualTo(FrenchCollation.Off));
-			ucaCollator.FrenchCollation = frenchCollation;
-			return ucaCollator.Compare(string1, string2);
+			using (var ucaCollator = new RuleBasedCollator(string.Empty))
+			{
+				Assert.That(ucaCollator.FrenchCollation, Is.EqualTo(FrenchCollation.Off));
+				ucaCollator.FrenchCollation = frenchCollation;
+				return ucaCollator.Compare(string1, string2);
+			}
 		}
 
 		private static Collator CreateJaCollator()
@@ -257,11 +279,13 @@ namespace Icu.Tests.Collation
                 H=X, S=4 きゅう = キュウ < きゆう = キユウ
                 H=O, S=4 きゅう < キュウ < きゆう < キユウ        
              */
-			var jaCollator = CreateJaCollator();
-			// In ICU54 the HiraganaQauternary special feature is deprecated in favor of supporting
-			// quaternary sorting as a regular feature.
-			jaCollator.Strength = collationStrength;
-			return jaCollator.Compare(string1, string2);
+			using (var jaCollator = CreateJaCollator())
+			{
+				// In ICU54 the HiraganaQauternary special feature is deprecated in favor of supporting
+				// quaternary sorting as a regular feature.
+				jaCollator.Strength = collationStrength;
+				return jaCollator.Compare(string1, string2);
+			}
 		}
 
 		[TestCase(NormalizationMode.Off, "ä", "a\u0308", Result = 0)]
@@ -288,8 +312,10 @@ namespace Icu.Tests.Collation
                 N=X ä = a + ◌̈ < ä + ◌̣ < ạ + ◌̈
                 N=O ä = a + ◌̈ < ä + ◌̣ = ạ + ◌̈
              */
-			var ucaCollator = new RuleBasedCollator(string.Empty, normalizationMode, CollationStrength.Default);
-			return ucaCollator.Compare(string1, string2);
+			using (var ucaCollator = new RuleBasedCollator(string.Empty, normalizationMode, CollationStrength.Default))
+			{
+				return ucaCollator.Compare(string1, string2);
+			}
 		}
 
 		//  1 < 10 < 2 < 20
@@ -303,10 +329,12 @@ namespace Icu.Tests.Collation
 		public int NumericCollationSetting(NumericCollation numericCollation, string string1,
 			string string2)
 		{
-			var ucaCollator = new RuleBasedCollator(string.Empty);
-			Assert.AreEqual(NumericCollation.Off, ucaCollator.NumericCollation);
-			ucaCollator.NumericCollation = numericCollation;
-			return ucaCollator.Compare(string1, string2);
+			using (var ucaCollator = new RuleBasedCollator(string.Empty))
+			{
+				Assert.AreEqual(NumericCollation.Off, ucaCollator.NumericCollation);
+				ucaCollator.NumericCollation = numericCollation;
+				return ucaCollator.Compare(string1, string2);
+			}
 		}
 
 		[TestCase(CollationStrength.Primary, "role", "Role", Result = 0)]
@@ -349,11 +377,13 @@ namespace Icu.Tests.Collation
                 S=2 role = Role < rôle
                 S=3 role < Role < rôle
                 A=S  S=4 ab < a c < a-c < ac*/
-			var ucaCollator = new RuleBasedCollator(string.Empty, collationStrength);
-			if (collationStrength == CollationStrength.Quaternary)
-				ucaCollator.AlternateHandling = AlternateHandling.Shifted;
-			Assert.That(ucaCollator.Strength, Is.EqualTo(collationStrength));
-			return ucaCollator.Compare(string1, string2);
+			using (var ucaCollator = new RuleBasedCollator(string.Empty, collationStrength))
+			{
+				if (collationStrength == CollationStrength.Quaternary)
+					ucaCollator.AlternateHandling = AlternateHandling.Shifted;
+				Assert.That(ucaCollator.Strength, Is.EqualTo(collationStrength));
+				return ucaCollator.Compare(string1, string2);
+			}
 		}
 
 		[Test]

--- a/source/icu.net.tests/icu.net.tests.csproj
+++ b/source/icu.net.tests/icu.net.tests.csproj
@@ -170,6 +170,9 @@
   <ItemGroup>
     <None Include="icu4c.readme.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
 	   Other similar extension points exist, see Microsoft.Common.targets.

--- a/source/icu.net.tests/icu.net.tests.csproj
+++ b/source/icu.net.tests/icu.net.tests.csproj
@@ -181,11 +181,11 @@
   <PropertyGroup>
     <PreBuildEvent />
   </PropertyGroup>
-  <Import Project="..\packages\Icu4c.Win.Full.Lib.54.1.7\build\Icu4c.Win.Full.Lib.targets" Condition="Exists('..\packages\Icu4c.Win.Full.Lib.54.1.7\build\Icu4c.Win.Full.Lib.targets')" />
+  <Import Project="..\packages\Icu4c.Win.Full.Lib.56.1.5\build\Icu4c.Win.Full.Lib.targets" Condition="Exists('..\packages\Icu4c.Win.Full.Lib.56.1.5\build\Icu4c.Win.Full.Lib.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Icu4c.Win.Full.Lib.54.1.7\build\Icu4c.Win.Full.Lib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Icu4c.Win.Full.Lib.54.1.7\build\Icu4c.Win.Full.Lib.targets'))" />
+    <Error Condition="!Exists('..\packages\Icu4c.Win.Full.Lib.56.1.5\build\Icu4c.Win.Full.Lib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Icu4c.Win.Full.Lib.56.1.5\build\Icu4c.Win.Full.Lib.targets'))" />
   </Target>
 </Project>

--- a/source/icu.net.tests/packages.config
+++ b/source/icu.net.tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Icu4c.Win.Full.Lib" version="54.1.7" targetFramework="net40" />
+  <package id="Icu4c.Win.Full.Lib" version="56.1.5" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
 </packages>

--- a/source/icu.net/BreakIterator.cs
+++ b/source/icu.net/BreakIterator.cs
@@ -76,17 +76,25 @@ namespace Icu
 		/// <param name="locale">The locale.</param>
 		/// <param name="text">The text.</param>
 		/// <returns>The tokens.</returns>
-		public static IEnumerable<string> Split(UBreakIteratorType type, Locale locale, string text)
+		public static IEnumerable<string> Split(UBreakIteratorType type, string locale, string text)
 		{
-			return Split(type, locale.Id, text);
+			return Split(type, new Locale(locale), text);
 		}
 
-		public static IEnumerable<string> Split(UBreakIteratorType type, string locale, string text)
+		/// <summary>
+		/// Splits the specified text along the specified type of boundaries. Spaces and punctuations
+		/// are not returned.
+		/// </summary>
+		/// <param name="type">The type.</param>
+		/// <param name="locale">The locale.</param>
+		/// <param name="text">The text.</param>
+		/// <returns>The tokens.</returns>
+		public static IEnumerable<string> Split(UBreakIteratorType type, Locale locale, string text)
 		{
 			if (string.IsNullOrEmpty(text))
 				yield break;
 
-			foreach (var boundary in GetBoundaries(type, locale, text, includeSpacesAndPunctuation: false))
+			foreach (var boundary in GetBoundaries(type, locale.Id, text, includeSpacesAndPunctuation: false))
 			{
 				yield return text.Substring(boundary.Start, boundary.End - boundary.Start);
 			}
@@ -100,12 +108,12 @@ namespace Icu
 		/// are desired; false otherwise.
 		/// For more information: http://userguide.icu-project.org/boundaryanalysis#TOC-Count-the-words-in-a-document-C-only-:
 		/// </param>
-		public static IEnumerable<Boundary> GetWordBoundaries(Locale locale, string text, bool includeSpacesAndPunctuation)
+		public static IEnumerable<Boundary> GetWordBoundaries(string locale, string text, bool includeSpacesAndPunctuation)
 		{
-			return GetWordBoundaries(locale.Id, text, includeSpacesAndPunctuation);
+			return GetWordBoundaries(new Locale(locale), text, includeSpacesAndPunctuation);
 		}
 
-		public static IEnumerable<Boundary> GetWordBoundaries(string locale, string text, bool includeSpacesAndPunctuation)
+		public static IEnumerable<Boundary> GetWordBoundaries(Locale locale, string text, bool includeSpacesAndPunctuation)
 		{
 			return GetBoundaries(UBreakIteratorType.WORD, locale, text, includeSpacesAndPunctuation);
 		}
@@ -116,16 +124,16 @@ namespace Icu
 		/// </summary>
 		public static IEnumerable<Boundary> GetBoundaries(UBreakIteratorType type, Locale locale, string text)
 		{
-			return GetBoundaries(type, locale.Id, text, false);
+			return GetBoundaries(type, locale, text, false);
 		}
 
-		private static IEnumerable<Boundary> GetBoundaries(UBreakIteratorType type, string locale, string text, bool includeSpacesAndPunctuation)
+		private static IEnumerable<Boundary> GetBoundaries(UBreakIteratorType type, Locale locale, string text, bool includeSpacesAndPunctuation)
 		{
 			if (string.IsNullOrEmpty(text))
 				yield break;
 
 			ErrorCode err;
-			IntPtr bi = NativeMethods.ubrk_open(type, locale, text, text.Length, out err);
+			IntPtr bi = NativeMethods.ubrk_open(type, locale.Id, text, text.Length, out err);
 			if (err.IsFailure())
 				throw new Exception("BreakIterator.Split() failed with code " + err);
 

--- a/source/icu.net/BreakIterator.cs
+++ b/source/icu.net/BreakIterator.cs
@@ -74,7 +74,7 @@ namespace Icu
 		private readonly bool _includeSpacesAndPunctuation;
 		private readonly UBreakIteratorType _iteratorType;
 		private readonly Locale _locale;
-		
+
 		private int _currentIndex = DONE;
 		private bool _disposingValue = false; // To detect redundant calls
 		private string _text;
@@ -118,27 +118,15 @@ namespace Icu
 		}
 
 		/// <summary>
-		/// Increments the iterator and returns the next Boundary.
-		/// Returns null if there are no boundaries left to return.
+		/// Gets all of the Boundaries for the given text.
+		/// Returns Boundary[0] if the text was empty or null.
 		/// </summary>
-		public virtual Boundary Next
-		{
-			get
-			{
-				if (_currentIndex == DONE)
-					return default(Boundary);
+		public virtual Boundary[] Boundaries { get; protected set; }
 
-				_currentIndex++;
-
-				if (_currentIndex >= Boundaries.Length)
-				{
-					_currentIndex = DONE;
-					return default(Boundary);
-				}
-
-				return Boundaries[_currentIndex];
-			}
-		}
+		/// <summary>
+		/// Gets the text being examined by this BreakIterator.
+		/// </summary>
+		public virtual string Text { get { return _text; } }
 
 		/// <summary>
 		/// The current Boundary.
@@ -159,64 +147,64 @@ namespace Icu
 		/// Decrements the iterator and returns the previous Boundary.
 		/// Returns null if the iterator moves past the first Boundary.
 		/// </summary>
-		public virtual Boundary Previous
+		public virtual Boundary MovePrevious()
 		{
-			get
+			if (_currentIndex == 0 || _currentIndex == DONE)
 			{
-				if (_currentIndex == 0 || _currentIndex == DONE)
-				{
-					_currentIndex = DONE;
-					return default(Boundary);
-				}
-
-				_currentIndex--;
-
-				return Boundaries[_currentIndex];
+				_currentIndex = DONE;
+				return default(Boundary);
 			}
+
+			_currentIndex--;
+
+			return Boundaries[_currentIndex];
+		}
+
+		/// <summary>
+		/// Increments the iterator and returns the next Boundary.
+		/// Returns null if there are no boundaries left to return.
+		/// </summary>
+		public virtual Boundary MoveNext()
+		{
+			if (_currentIndex == DONE)
+				return default(Boundary);
+
+			_currentIndex++;
+
+			if (_currentIndex >= Boundaries.Length)
+			{
+				_currentIndex = DONE;
+				return default(Boundary);
+			}
+
+			return Boundaries[_currentIndex];
 		}
 
 		/// <summary>
 		/// Sets the iterator to the first Boundary and returns it.
 		/// Returns null if there was no text set.
 		/// </summary>
-		public virtual Boundary First
+		public virtual Boundary MoveFirst()
 		{
-			get
-			{
-				if (Boundaries.Length == 0)
-					return default(Boundary);
+			if (Boundaries.Length == 0)
+				return default(Boundary);
 
-				_currentIndex = 0;
-				return Boundaries[_currentIndex];
-			}
+			_currentIndex = 0;
+			return Boundaries[_currentIndex];
 		}
 
 		/// <summary>
 		/// Sets the iterator to the last Boundary and returns it.
 		/// Returns null if there was no text set.
 		/// </summary>
-		public virtual Boundary Last
+		public virtual Boundary MoveLast()
 		{
-			get
-			{
-				if (Boundaries.Length == 0)
-					return default(Boundary);
+			if (Boundaries.Length == 0)
+				return default(Boundary);
 
-				_currentIndex = Boundaries.Length - 1;
-				return Boundaries[_currentIndex];
-			}
+			_currentIndex = Boundaries.Length - 1;
+			return Boundaries[_currentIndex];
 		}
-
-		/// <summary>
-		/// Gets all of the Boundaries for the given text.
-		/// Returns Boundary[0] if the text was empty or null.
-		/// </summary>
-		public virtual Boundary[] Boundaries { get; protected set; }
-
-		/// <summary>
-		/// Gets the text being examined by this BreakIterator.
-		/// </summary>
-		public virtual string Text { get { return _text; } }
 
 		/// <summary>
 		/// Sets the current text being examined to the given text.

--- a/source/icu.net/BreakIterator.cs
+++ b/source/icu.net/BreakIterator.cs
@@ -450,12 +450,9 @@ namespace Icu
 		/// Creates a BreakIterator that splits on characters for the given locale.
 		/// </summary>
 		/// <param name="locale">The locale.</param>
-		/// <param name="text">The initial text.</param>
-		public static BreakIterator CreateCharacterInstance(Locale locale, string text)
+		public static BreakIterator CreateCharacterInstance(Locale locale)
 		{
-			var iterator = new RuleBasedBreakIterator(UBreakIteratorType.CHARACTER, locale);
-			iterator.SetText(text);
-			return iterator;
+			return new RuleBasedBreakIterator(UBreakIteratorType.CHARACTER, locale);
 		}
 
 		/// <summary>
@@ -467,12 +464,9 @@ namespace Icu
 		/// or <see cref="BreakIterator.GetWordBoundaries(Locale, string, bool)"/>,
 		/// </summary>
 		/// <param name="locale">The locale.</param>
-		/// <param name="text">The initial text.</param>
-		public static BreakIterator CreateWordInstance(Locale locale, string text)
+		public static BreakIterator CreateWordInstance(Locale locale)
 		{
-			var iterator = new RuleBasedBreakIterator(UBreakIteratorType.WORD, locale);
-			iterator.SetText(text);
-			return iterator;
+			return new RuleBasedBreakIterator(UBreakIteratorType.WORD, locale);
 		}
 
 		/// <summary>
@@ -480,11 +474,9 @@ namespace Icu
 		/// </summary>
 		/// <param name="locale">The locale.</param>
 		/// <param name="text">The initial text.</param>
-		public static BreakIterator CreateLineInstance(Locale locale, string text)
+		public static BreakIterator CreateLineInstance(Locale locale)
 		{
-			var iterator = new RuleBasedBreakIterator(UBreakIteratorType.LINE, locale);
-			iterator.SetText(text);
-			return iterator;
+			return new RuleBasedBreakIterator(UBreakIteratorType.LINE, locale);
 		}
 
 		/// <summary>
@@ -492,11 +484,9 @@ namespace Icu
 		/// </summary>
 		/// <param name="locale">The locale.</param>
 		/// <param name="text">The initial text.</param>
-		public static BreakIterator CreateSentenceInstance(Locale locale, string text)
+		public static BreakIterator CreateSentenceInstance(Locale locale)
 		{
-			var iterator = new RuleBasedBreakIterator(UBreakIteratorType.SENTENCE, locale);
-			iterator.SetText(text);
-			return iterator;
+			return new RuleBasedBreakIterator(UBreakIteratorType.SENTENCE, locale);
 		}
 
 		/// <summary>

--- a/source/icu.net/BreakIterator.cs
+++ b/source/icu.net/BreakIterator.cs
@@ -44,13 +44,38 @@ namespace Icu
 			/// Upper bound for tags for uncategorized words.
 			/// </summary>
 			NONE_LIMIT     = 100,
+			/// <summary>
+			/// Tag value for words that appear to be numbers, lower limit.
+			/// </summary>
 			NUMBER         = 100,
+			/// <summary>
+			/// Tag value for words that appear to be numbers, upper limit.
+			/// </summary>
 			NUMBER_LIMIT   = 200,
+			/// <summary>
+			/// Tag value for words that contain letters, excluding hiragana,
+			/// katakana or ideographic characters, lower limit.
+			/// </summary>
 			LETTER         = 200,
+			/// <summary>
+			/// Tag value for words containing letters, upper limit.
+			/// </summary>
 			LETTER_LIMIT   = 300,
+			/// <summary>
+			/// Tag value for words containing kana characters, lower limit.
+			/// </summary>
 			KANA           = 300,
+			/// <summary>
+			/// Tag value for words containing kana characters, upper limit.
+			/// </summary>
 			KANA_LIMIT     = 400,
+			/// <summary>
+			/// Tag value for words containing ideographic characters, lower limit.
+			/// </summary>
 			IDEO           = 400,
+			/// <summary>
+			/// Tag value for words containing ideographic characters, upper limit.
+			/// </summary>
 			IDEO_LIMIT     = 500,
 		}
 

--- a/source/icu.net/BreakIterator.cs
+++ b/source/icu.net/BreakIterator.cs
@@ -373,6 +373,12 @@ namespace Icu
 		/// Dispose of managed/unmanaged resources.
 		/// Allow any inheriting classes to dispose of manage
 		/// </summary>
-		public virtual void Dispose() { }
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected virtual void Dispose(bool disposing) { }
 	}
 }

--- a/source/icu.net/BreakIterator.cs
+++ b/source/icu.net/BreakIterator.cs
@@ -221,10 +221,121 @@ namespace Icu
 		/// </summary>
 		public virtual int MoveLast()
 		{
-			if (string.IsNullOrEmpty(Text))
+			if (Text == null)
+			{
+				return DONE;
+			}
+			else if (Text.Equals(string.Empty))
+			{
 				return 0;
+			}
 
 			_currentIndex = Boundaries.Length - 1;
+			return _textBoundaries[_currentIndex].Offset;
+		}
+
+		/// <summary>
+		/// Sets the iterator to refer to the first boundary position following
+		/// the specified position.
+		/// </summary>
+		/// <param name="offset">The position from which to begin searching for
+		/// a break position.</param>
+		/// <returns>The position of the first break after the current position.
+		/// The value returned is always greater than offset, or <see cref="BreakIterator.DONE"/>
+		/// </returns>
+		public virtual int MoveFollowing(int offset)
+		{
+			// if the offset passed in is already past the end of the text,
+			// just return DONE; if it's before the beginning, return the
+			// text's starting offset
+			if (Text == null || offset >= Text.Length)
+			{
+				MoveLast();
+				return MoveNext();
+			}
+			else if (offset < 0)
+			{
+				return MoveFirst();
+			}
+
+			if (offset == _textBoundaries[0].Offset)
+			{
+				_currentIndex = 0;
+				return MoveNext();
+			}
+			else if (offset == _textBoundaries[_textBoundaries.Length - 1].Offset)
+			{
+				_currentIndex = _textBoundaries.Length - 1;
+				return MoveNext();
+			}
+			else
+			{
+				int index = 1;
+				// We are guaranteed not to leave the array due to range test above
+				while (offset >= _textBoundaries[index].Offset)
+				{
+					index++;
+				}
+
+				_currentIndex = index;
+				return _textBoundaries[_currentIndex].Offset;
+			}
+		}
+
+		/// <summary>
+		/// Sets the iterator to refer to the last boundary position before the
+		/// specified position.
+		/// </summary>
+		/// <param name="offset">The position to begin searching for a break from.</param>
+		/// <returns>The position of the last boundary before the starting
+		/// position. The value returned is always smaller than the offset
+		/// or the value <see cref="BreakIterator.DONE"/></returns>
+		public virtual int MovePreceding(int offset)
+		{
+			if (Text == null || offset > Text.Length)
+			{
+				return MoveLast();
+			}
+			else if (offset < 0)
+			{
+				return MoveFirst();
+			}
+
+			// If the offset is less than the first boundary, return the first
+			// boundary. Else if, the offset is greater than the last boundary,
+			// return the last boundary.
+			// Otherwise, the offset is somewhere in the middle. So we start
+			// iterating through the boundaries until we get to a point where
+			// the current boundary we are at has a greater offset than the given
+			// one. So we return that.
+			if (_textBoundaries.Length == 0 || offset == _textBoundaries[0].Offset)
+			{
+				_currentIndex = 0;
+				return DONE;
+			}
+			else if (offset < _textBoundaries[0].Offset)
+			{
+				_currentIndex = 0;
+			}
+			else if (offset > _textBoundaries[_textBoundaries.Length - 1].Offset)
+			{
+				_currentIndex = _textBoundaries.Length - 1;
+			}
+			else
+			{
+				int index = 0;
+
+				while (index < _textBoundaries.Length
+					  && offset > _textBoundaries[index].Offset)
+				{
+					index++;
+				}
+
+				index--;
+
+				_currentIndex = index;
+			}
+
 			return _textBoundaries[_currentIndex].Offset;
 		}
 

--- a/source/icu.net/Collation/Collator.cs
+++ b/source/icu.net/Collation/Collator.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace Icu.Collation
 {
-	public abstract class Collator : IComparer<string>, ICloneable
+	public abstract class Collator : IComparer<string>, ICloneable, IDisposable
 	{
 		public abstract CollationStrength Strength{ get; set; }
 
@@ -280,6 +280,22 @@ namespace Icu.Collation
 					throw new Exception("Collator.GetSortKeyBound() failed with code " + err);
 			}
 		}
+
+		#region IDisposable Support
+
+		/// <summary>
+		/// Dispose of managed/unmanaged resources.
+		/// Allow any inheriting classes to dispose of manage
+		/// </summary>
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected virtual void Dispose(bool disposing) { }
+
+		#endregion
 
 	}
 }

--- a/source/icu.net/Collation/RuleBasedCollator.cs
+++ b/source/icu.net/Collation/RuleBasedCollator.cs
@@ -471,7 +471,7 @@ namespace Icu.Collation
 		#region IDisposable Support
 
 		/// <summary>
-		/// Implementing IDisposable pattern to properly release unmanaged resources. 
+		/// Implementing IDisposable pattern to properly release unmanaged resources.
 		/// </summary>
 		protected override void Dispose(bool disposing)
 		{

--- a/source/icu.net/Collation/RuleBasedCollator.cs
+++ b/source/icu.net/Collation/RuleBasedCollator.cs
@@ -41,7 +41,8 @@ namespace Icu.Collation
 			}
 		}
 
-		private SafeRuleBasedCollatorHandle _collatorHandle;
+		private bool _disposingValue = false; // To detect redundant calls
+		private SafeRuleBasedCollatorHandle _collatorHandle = default(SafeRuleBasedCollatorHandle);
 
 		private RuleBasedCollator() {}
 
@@ -467,5 +468,34 @@ namespace Icu.Collation
 
 		#endregion
 
+		#region IDisposable Support
+
+		/// <summary>
+		/// Implementing IDisposable pattern to properly release unmanaged resources. 
+		/// </summary>
+		protected override void Dispose(bool disposing)
+		{
+			if (!_disposingValue)
+			{
+				if (disposing)
+				{
+					// Dispose managed state (managed objects), if any.
+				}
+
+				if (_collatorHandle != default(SafeRuleBasedCollatorHandle))
+				{
+					_collatorHandle.Dispose();
+				}
+
+				_disposingValue = true;
+			}
+		}
+
+		~RuleBasedCollator()
+		{
+			Dispose(false);
+		}
+
+		#endregion
 	}
 }

--- a/source/icu.net/ErrorCode.cs
+++ b/source/icu.net/ErrorCode.cs
@@ -7,7 +7,7 @@ using System.IO;
 
 namespace Icu
 {
-	internal enum ErrorCode
+	public enum ErrorCode
 	{
 		USING_FALLBACK_WARNING = -128,   /** A resource bundle lookup returned a fallback result (not an error) */
 

--- a/source/icu.net/NativeMethods.cs
+++ b/source/icu.net/NativeMethods.cs
@@ -1442,6 +1442,24 @@ namespace Icu
 		}
 
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate void ubrk_setTextDelegate(IntPtr bi, string text, int textLength, out ErrorCode errorCode);
+
+		private static ubrk_setTextDelegate _ubrk_setText;
+
+		/// <summary>
+		/// Sets the iterator to a new text
+		/// </summary>
+		/// <param name="bi">The break iterator.</param>
+		/// <param name="text">Text to examine</param>
+		public static void ubrk_setText(IntPtr bi, string text, int textLength, out ErrorCode errorCode)
+		{
+			if (_ubrk_setText == null)
+				_ubrk_setText = GetMethod<ubrk_setTextDelegate>(IcuCommonLibHandle, "ubrk_setText", true);
+
+			_ubrk_setText(bi, text, textLength, out errorCode);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
 		private delegate void ubrk_closeDelegate(IntPtr bi);
 
 		private static ubrk_closeDelegate _ubrk_close;

--- a/source/icu.net/NativeMethods.cs
+++ b/source/icu.net/NativeMethods.cs
@@ -1442,6 +1442,31 @@ namespace Icu
 		}
 
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate IntPtr ubrk_openRulesDelegate(string rules, int rulesLength,
+			string text, int textLength, out ParseError parseError, out ErrorCode errorCode);
+
+		private static ubrk_openRulesDelegate _ubrk_openRules;
+
+		/// <summary>
+		/// Open a new BreakIterator that uses the given rules to break text.
+		/// </summary>
+		/// <param name="rules">The rules to use for break iterator</param>
+		/// <param name="rulesLength">The length of the rules.</param>
+		/// <param name="text">The text.</param>
+		/// <param name="textLength">Length of the text.</param>
+		/// <param name="errorCode">The error code.</param>
+		/// <returns></returns>
+		public static IntPtr ubrk_openRules(
+			string rules, int rulesLength,
+			string text, int textLength,
+			out ParseError parseError, out ErrorCode errorCode)
+		{
+			if (_ubrk_openRules == null)
+				_ubrk_openRules = GetMethod<ubrk_openRulesDelegate>(IcuCommonLibHandle, "ubrk_openRules", true);
+			return _ubrk_openRules(rules, rulesLength, text, textLength, out parseError, out errorCode);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
 		private delegate void ubrk_setTextDelegate(IntPtr bi, string text, int textLength, out ErrorCode errorCode);
 
 		private static ubrk_setTextDelegate _ubrk_setText;

--- a/source/icu.net/NativeMethods.cs
+++ b/source/icu.net/NativeMethods.cs
@@ -1526,6 +1526,39 @@ namespace Icu
 			return _ubrk_getRuleStatus(bi);
 		}
 
+		/// <summary>
+		/// Get the statuses from the break rules that determined the most
+		/// recently returned break position.  The values appear in the rule
+		/// source within brackets, {123}, for example.The default status value
+		/// for rules that do not explicitly provide one is zero.
+		///
+		/// For word break iterators, the possible values are defined in
+		/// <see cref="Icu.BreakIterator.UWordBreak"/>
+		/// </summary>
+		/// <returns>The number of rule status values that determined the most recent boundary returned from the break iterator.</returns>
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+		private delegate int ubrk_getRuleStatusVecDelegate(IntPtr bi,
+			[Out, MarshalAs(UnmanagedType.LPArray)]Int32[] fillInVector,
+			Int32 capacity,
+			out ErrorCode status);
+
+		private static ubrk_getRuleStatusVecDelegate _ubrk_getRuleStatusVec;
+
+		/// <summary>
+		/// Return the status from the break rule that determined the most recently returned break position.
+		/// </summary>
+		/// <param name="bi">The break iterator.</param>
+		/// <returns></returns>
+		public static int ubrk_getRuleStatusVec(IntPtr bi,
+			[Out, MarshalAs(UnmanagedType.LPArray)]Int32[] fillInVector,
+			Int32 capacity,
+			out ErrorCode status)
+		{
+			if (_ubrk_getRuleStatusVec == null)
+				_ubrk_getRuleStatusVec = GetMethod<ubrk_getRuleStatusVecDelegate>(IcuCommonLibHandle, "ubrk_getRuleStatusVec", true);
+			return _ubrk_getRuleStatusVec(bi, fillInVector, capacity, out status);
+		}
+
 		#endregion Break iterator
 
 		#region Unicode set

--- a/source/icu.net/NativeMethods.cs
+++ b/source/icu.net/NativeMethods.cs
@@ -828,6 +828,10 @@ namespace Icu
 				string locale, string text, int textLength, out ErrorCode errorCode);
 
 			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			internal delegate IntPtr ubrk_openRulesDelegate(string rules, int rulesLength,
+				string text, int textLength, out ParseError parseError, out ErrorCode errorCode);
+
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
 			internal delegate void ubrk_closeDelegate(IntPtr bi);
 
 			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
@@ -838,6 +842,25 @@ namespace Icu
 
 			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
 			internal delegate int ubrk_getRuleStatusDelegate(IntPtr bi);
+
+			/// <summary>
+			/// Get the statuses from the break rules that determined the most
+			/// recently returned break position.  The values appear in the rule
+			/// source within brackets, {123}, for example.The default status value
+			/// for rules that do not explicitly provide one is zero.
+			///
+			/// For word break iterators, the possible values are defined in
+			/// <see cref="Icu.BreakIterator.UWordBreak"/>
+			/// </summary>
+			/// <returns>The number of rule status values that determined the most recent boundary returned from the break iterator.</returns>
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			internal delegate int ubrk_getRuleStatusVecDelegate(IntPtr bi,
+				[Out, MarshalAs(UnmanagedType.LPArray)]Int32[] fillInVector,
+				Int32 capacity,
+				out ErrorCode status);
+
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			internal delegate void ubrk_setTextDelegate(IntPtr bi, string text, int textLength, out ErrorCode errorCode);
 
 			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
 			internal delegate void uset_closeDelegate(IntPtr set);
@@ -919,10 +942,13 @@ namespace Icu
 			internal unorm_normalizeDelegate _unorm_normalize;
 			internal unorm_isNormalizedDelegate _unorm_isNormalized;
 			internal ubrk_openDelegate ubrk_open;
+			internal ubrk_openRulesDelegate ubrk_openRules;
 			internal ubrk_closeDelegate ubrk_close;
 			internal ubrk_firstDelegate ubrk_first;
 			internal ubrk_nextDelegate ubrk_next;
 			internal ubrk_getRuleStatusDelegate ubrk_getRuleStatus;
+			internal ubrk_getRuleStatusVecDelegate ubrk_getRuleStatusVec;
+			internal ubrk_setTextDelegate ubrk_setText;
 			internal uset_closeDelegate uset_close;
 			internal uset_openDelegate uset_open;
 			internal uset_openPatternDelegate uset_openPattern;
@@ -1477,12 +1503,6 @@ namespace Icu
 			return Methods.ubrk_open(type, locale, text, textLength, out errorCode);
 		}
 
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		private delegate IntPtr ubrk_openRulesDelegate(string rules, int rulesLength,
-			string text, int textLength, out ParseError parseError, out ErrorCode errorCode);
-
-		private static ubrk_openRulesDelegate _ubrk_openRules;
-
 		/// <summary>
 		/// Open a new BreakIterator that uses the given rules to break text.
 		/// </summary>
@@ -1497,15 +1517,10 @@ namespace Icu
 			string text, int textLength,
 			out ParseError parseError, out ErrorCode errorCode)
 		{
-			if (_ubrk_openRules == null)
-				_ubrk_openRules = GetMethod<ubrk_openRulesDelegate>(IcuCommonLibHandle, "ubrk_openRules", true);
-			return _ubrk_openRules(rules, rulesLength, text, textLength, out parseError, out errorCode);
+			if (Methods.ubrk_openRules == null)
+				Methods.ubrk_openRules = GetMethod<MethodsContainer.ubrk_openRulesDelegate>(IcuCommonLibHandle, "ubrk_openRules", true);
+			return Methods.ubrk_openRules(rules, rulesLength, text, textLength, out parseError, out errorCode);
 		}
-
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		private delegate void ubrk_setTextDelegate(IntPtr bi, string text, int textLength, out ErrorCode errorCode);
-
-		private static ubrk_setTextDelegate _ubrk_setText;
 
 		/// <summary>
 		/// Sets the iterator to a new text
@@ -1514,16 +1529,10 @@ namespace Icu
 		/// <param name="text">Text to examine</param>
 		public static void ubrk_setText(IntPtr bi, string text, int textLength, out ErrorCode errorCode)
 		{
-			if (_ubrk_setText == null)
-				_ubrk_setText = GetMethod<ubrk_setTextDelegate>(IcuCommonLibHandle, "ubrk_setText", true);
-
-			_ubrk_setText(bi, text, textLength, out errorCode);
+			if (Methods.ubrk_setText == null)
+				Methods.ubrk_setText = GetMethod<MethodsContainer.ubrk_setTextDelegate>(IcuCommonLibHandle, "ubrk_setText", true);
+			Methods.ubrk_setText(bi, text, textLength, out errorCode);
 		}
-
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		private delegate void ubrk_closeDelegate(IntPtr bi);
-
-		private static ubrk_closeDelegate _ubrk_close;
 
 		/// <summary>
 		/// Close a UBreakIterator.
@@ -1573,24 +1582,6 @@ namespace Icu
 		}
 
 		/// <summary>
-		/// Get the statuses from the break rules that determined the most
-		/// recently returned break position.  The values appear in the rule
-		/// source within brackets, {123}, for example.The default status value
-		/// for rules that do not explicitly provide one is zero.
-		///
-		/// For word break iterators, the possible values are defined in
-		/// <see cref="Icu.BreakIterator.UWordBreak"/>
-		/// </summary>
-		/// <returns>The number of rule status values that determined the most recent boundary returned from the break iterator.</returns>
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-		private delegate int ubrk_getRuleStatusVecDelegate(IntPtr bi,
-			[Out, MarshalAs(UnmanagedType.LPArray)]Int32[] fillInVector,
-			Int32 capacity,
-			out ErrorCode status);
-
-		private static ubrk_getRuleStatusVecDelegate _ubrk_getRuleStatusVec;
-
-		/// <summary>
 		/// Return the status from the break rule that determined the most recently returned break position.
 		/// </summary>
 		/// <param name="bi">The break iterator.</param>
@@ -1600,9 +1591,9 @@ namespace Icu
 			Int32 capacity,
 			out ErrorCode status)
 		{
-			if (_ubrk_getRuleStatusVec == null)
-				_ubrk_getRuleStatusVec = GetMethod<ubrk_getRuleStatusVecDelegate>(IcuCommonLibHandle, "ubrk_getRuleStatusVec", true);
-			return _ubrk_getRuleStatusVec(bi, fillInVector, capacity, out status);
+			if (Methods.ubrk_getRuleStatusVec == null)
+				Methods.ubrk_getRuleStatusVec = GetMethod<MethodsContainer.ubrk_getRuleStatusVecDelegate>(IcuCommonLibHandle, "ubrk_getRuleStatusVec", true);
+			return Methods.ubrk_getRuleStatusVec(bi, fillInVector, capacity, out status);
 		}
 
 		#endregion Break iterator

--- a/source/icu.net/ParseError.cs
+++ b/source/icu.net/ParseError.cs
@@ -47,14 +47,14 @@ namespace Icu
 				throw new ArgumentNullException();
 			}
 
-			string result = "\nAt " ;
+			string result = Environment.NewLine + "At " ;
 			if (Line > 0)
 			{
 				result += "Line " + Line + ' ';
 			}
 			if (Offset >= 0)
 			{
-				result += "Offset " + Offset + '\n';
+				result += "Offset " + Offset + Environment.NewLine;
 			}
 
 			string ruleError = string.Empty;
@@ -62,8 +62,8 @@ namespace Icu
 			{
 				if (rules.Length > 0 && Offset > 0)
 				{
-					ruleError = GetLine(rules, Line) + '\n';
-					ruleError += new string('-', Offset - 1) + "^\n";
+					ruleError = GetLine(rules, Line) + Environment.NewLine;
+					ruleError += new string('-', Offset - 1) + "^" + Environment.NewLine;
 				}
 			}
 			catch
@@ -72,13 +72,13 @@ namespace Icu
 			}
 			result += ruleError;
 
-			result += "PreContext: " + PreContext + '\n' + "PostContext: " + PostContext;
+			result += "PreContext: " + PreContext + Environment.NewLine + "PostContext: " + PostContext;
 			return result;
 		}
 
 		static private string GetLine(string text, int line)
 		{
-			return text.Split('\n')[line];
+			return text.Split(new string[] { Environment.NewLine }, StringSplitOptions.None)[line];
 		}
 	}
 }

--- a/source/icu.net/ParseErrorException.cs
+++ b/source/icu.net/ParseErrorException.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace Icu
+{
+	/// <summary>
+	/// Exception when RuleBasedBreakIterator is unable to parse the rules.
+	/// </summary>
+	public class ParseErrorException : Exception
+	{
+		private readonly ParseError _error;
+		private readonly string _rules;
+
+		public ParseErrorException(string message, ParseError error, string rules)
+			: base(message)
+		{
+			if (rules == null)
+			{
+				throw new ArgumentNullException("rules");
+			}
+
+			_error = error;
+			_rules = rules;
+		}
+
+		public int Line { get { return _error.Line; } }
+		public int Offset { get { return _error.Offset; } }
+		public string PreContext { get { return _error.PreContext; } }
+		public string PostContext { get { return _error.PostContext; } }
+		public string Rules { get { return _rules; } }
+
+		public override string ToString()
+		{
+			return Message + Environment.NewLine + _error.ToString(_rules);
+		}
+	}
+}

--- a/source/icu.net/RuleBasedBreakIterator.cs
+++ b/source/icu.net/RuleBasedBreakIterator.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Icu
+{
+	/// <summary>
+	/// A subclass of BreakIterator whose behavior is specified using a list of rules.
+	/// Instances of this class are most commonly created by the factory methods of
+	/// <see cref="BreakIterator.CreateWordInstance(Locale, string)"/>, 
+	/// <see cref="BreakIterator.CreateLineInstance(Locale, string)"/> etc.,
+	/// and then used via the abstract API in class BreakIterator
+	/// </summary>
+	public class RuleBasedBreakIterator : BreakIterator
+	{
+		private readonly UBreakIteratorType _iteratorType;
+		private readonly string _rules = null;
+
+		private bool _disposingValue = false; // To detect redundant calls
+		private IntPtr _breakIterator = IntPtr.Zero;
+
+		/// <summary>
+		/// Creates a BreakIterator with the given BreakIteratorType, Locale.
+		/// </summary>
+		/// <param name="iteratorType">Break type.</param>
+		/// <param name="locale">The locale.</param>
+		/// <remarks>
+		/// If iterator type is UBreakIteratorType.WORD, it will include
+		/// spaces and punctuation as boundaries for words.  If this is 
+		/// not desired <see cref="BreakIterator.GetBoundaries(BreakIterator.UBreakIteratorType, Locale, string, bool)"/>.
+		/// </remarks>
+		public RuleBasedBreakIterator(UBreakIteratorType iteratorType, Locale locale)
+			: base(locale)
+		{
+			_iteratorType = iteratorType;
+		}
+
+		/// <summary>
+		/// Creates a RuleBasedBreakIterator with the given rules.
+		/// </summary>
+		public RuleBasedBreakIterator(string rules)
+			: base(DefaultLocale)
+		{
+			_rules = rules;
+		}
+
+		public override void SetText(string text)
+		{
+			base.SetText(text);
+
+			if (string.IsNullOrEmpty(Text))
+			{
+				_textBoundaries = new TextBoundary[0];
+				_currentIndex = 0;
+				return;
+			}
+
+			if (_breakIterator == IntPtr.Zero)
+			{
+				InitializeBreakIterator();
+			}
+			else
+			{
+				ErrorCode err;
+
+				NativeMethods.ubrk_setText(_breakIterator, Text, Text.Length, out err);
+
+				if (err.IsFailure())
+					throw new Exception("BreakIterator.ubrk_setText() failed with code " + err);
+			}
+
+			List<TextBoundary> textBoundaries = new List<TextBoundary>();
+
+			// Function that checks if the offset is valid, gets the RuleStatus
+			// and RuleStatusVector for the offset and then adds it to
+			// textBoundaries.  Returns true if the boundary was not DONE.
+			Func<int, bool> checkOffsetAndAddRuleStatus = (int offset) => {
+
+				if (offset == DONE)
+					return false;
+
+				const int length = 128;
+
+				int[] vector = new int[length];
+
+				ErrorCode errorCode;
+				int actualLen = NativeMethods.ubrk_getRuleStatusVec(_breakIterator, vector, length, out errorCode);
+
+				if (errorCode.IsFailure())
+					throw new Exception("BreakIterator.GetRuleStatusVector failed! " + errorCode);
+
+				if (actualLen > length)
+				{
+					vector = new int[actualLen];
+					NativeMethods.ubrk_getRuleStatusVec(_breakIterator, vector, vector.Length, out errorCode);
+
+					if (errorCode.IsFailure())
+						throw new Exception("BreakIterator.GetRuleStatusVector failed! " + errorCode);
+				}
+
+				int[] ruleStatuses;
+
+				// Constrain the size of the array to actual number of elements
+				// that were returned.
+				if (actualLen < vector.Length)
+				{
+					ruleStatuses = new int[actualLen];
+					Array.Copy(vector, ruleStatuses, actualLen);
+				}
+				else
+				{
+					ruleStatuses = vector;
+				}
+
+				textBoundaries.Add(new TextBoundary(offset, ruleStatuses));
+
+				return true;
+			};
+
+			// Start at the the beginning of the text and iterate until all
+			// of the boundaries are consumed.
+			int cur = NativeMethods.ubrk_first(_breakIterator);
+
+			if (!checkOffsetAndAddRuleStatus(cur))
+				return;
+
+			while (cur != DONE)
+			{
+				int next = NativeMethods.ubrk_next(_breakIterator);
+
+				if (!checkOffsetAndAddRuleStatus(next))
+					break;
+
+				cur = next;
+			}
+
+			_textBoundaries = textBoundaries.ToArray();
+			_currentIndex = 0;
+		}
+
+		/// <summary>
+		/// Initialises or returns unmanaged pointer to BreakIterator
+		/// </summary>
+		/// <returns></returns>
+		private void InitializeBreakIterator()
+		{
+			if (_breakIterator != IntPtr.Zero)
+			{
+				return;
+			}
+
+			if (_rules != null)
+			{
+				ErrorCode errorCode;
+				ParseError parseError;
+
+				_breakIterator = NativeMethods.ubrk_openRules(_rules, _rules.Length, Text, Text.Length, out parseError, out errorCode);
+
+				if (errorCode.IsFailure())
+				{
+					throw new InvalidOperationException(
+						string.Format("Could not create a BreakIterator with the given rules. Parse Error: {0}" + Environment.NewLine + "Rules: {1}", parseError.ToString(), _rules));
+				}
+			}
+			else
+			{
+				ErrorCode errorCode;
+				_breakIterator = NativeMethods.ubrk_open(_iteratorType, _locale.Id, Text, Text.Length, out errorCode);
+				if (errorCode.IsFailure())
+				{
+					throw new InvalidOperationException(
+						string.Format("Could not create a BreakIterator with locale [{0}], BreakIteratorType [{1}] and Text [{2}]", _locale.Id, _iteratorType, Text));
+				}
+			}
+		}
+
+		/// <summary>
+		/// If the RuleBasedBreakIterator was created using custom rules,
+		/// returns those rules as its string interpretation, otherwise,
+		/// returns the locale and BreakIteratorType.
+		/// </summary>
+		public override string ToString()
+		{
+			if (_rules == null)
+			{
+				return string.Format("Locale: {0}, BreakIteratorType: {1}", _locale, _iteratorType);
+			}
+			else
+			{
+				return _rules;
+			}
+		}
+
+		#region IDisposable Support
+
+		/// <summary>
+		/// Implementing IDisposable pattern to properly release unmanaged resources. 
+		/// See https://msdn.microsoft.com/en-us/library/b1yfkh5e(v=vs.110).aspx
+		/// and https://msdn.microsoft.com/en-us/library/b1yfkh5e(v=vs.100).aspx
+		/// for more information.
+		/// </summary>
+		/// <param name="disposing"></param>
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!_disposingValue)
+			{
+				if (disposing)
+				{
+					// Dispose managed state (managed objects), if any.
+				}
+
+				if (_breakIterator != IntPtr.Zero)
+				{
+					NativeMethods.ubrk_close(_breakIterator);
+					_breakIterator = IntPtr.Zero;
+				}
+
+				_disposingValue = true;
+			}
+		}
+
+		~RuleBasedBreakIterator()
+		{
+			Dispose(false);
+		}
+
+		public override void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		#endregion
+	}
+}

--- a/source/icu.net/RuleBasedBreakIterator.cs
+++ b/source/icu.net/RuleBasedBreakIterator.cs
@@ -157,8 +157,7 @@ namespace Icu
 
 				if (errorCode.IsFailure())
 				{
-					throw new InvalidOperationException(
-						string.Format("Could not create a BreakIterator with the given rules. Parse Error: {0}" + Environment.NewLine + "Rules: {1}", parseError.ToString(), _rules));
+					throw new ParseErrorException("Couldn't create RuleBasedBreakIterator with the given rules!", parseError, _rules);
 				}
 			}
 			else

--- a/source/icu.net/RuleBasedBreakIterator.cs
+++ b/source/icu.net/RuleBasedBreakIterator.cs
@@ -9,7 +9,7 @@ namespace Icu
 	/// <summary>
 	/// A subclass of BreakIterator whose behavior is specified using a list of rules.
 	/// Instances of this class are most commonly created by the factory methods of
-	/// <see cref="BreakIterator.CreateWordInstance(Locale, string)"/>, 
+	/// <see cref="BreakIterator.CreateWordInstance(Locale, string)"/>,
 	/// <see cref="BreakIterator.CreateLineInstance(Locale, string)"/> etc.,
 	/// and then used via the abstract API in class BreakIterator
 	/// </summary>
@@ -39,7 +39,7 @@ namespace Icu
 		/// <param name="locale">The locale.</param>
 		/// <remarks>
 		/// If iterator type is UBreakIteratorType.WORD, it will include
-		/// spaces and punctuation as boundaries for words.  If this is 
+		/// spaces and punctuation as boundaries for words.  If this is
 		/// not desired <see cref="BreakIterator.GetBoundaries(BreakIterator.UBreakIteratorType, Locale, string, bool)"/>.
 		/// </remarks>
 		public RuleBasedBreakIterator(UBreakIteratorType iteratorType, Locale locale)
@@ -401,7 +401,8 @@ namespace Icu
 			// Function that checks if the offset is valid, gets the RuleStatus
 			// and RuleStatusVector for the offset and then adds it to
 			// textBoundaries.  Returns true if the boundary was not DONE.
-			Func<int, bool> checkOffsetAndAddRuleStatus = (int offset) => {
+			Func<int, bool> checkOffsetAndAddRuleStatus = (int offset) =>
+			{
 
 				if (offset == DONE)
 					return false;
@@ -520,7 +521,7 @@ namespace Icu
 		#region IDisposable Support
 
 		/// <summary>
-		/// Implementing IDisposable pattern to properly release unmanaged resources. 
+		/// Implementing IDisposable pattern to properly release unmanaged resources.
 		/// See https://msdn.microsoft.com/en-us/library/b1yfkh5e(v=vs.110).aspx
 		/// and https://msdn.microsoft.com/en-us/library/b1yfkh5e(v=vs.100).aspx
 		/// for more information.
@@ -572,7 +573,7 @@ namespace Icu
 				// ubrk_getRuleStatus() will return the numerically largest
 				// from the vector.  We are saving a PInvoke by finding the max
 				// value.
-				// http://userguide.icu-project.org/boundaryanalysis#TOC-Rule-Status-Values 
+				// http://userguide.icu-project.org/boundaryanalysis#TOC-Rule-Status-Values
 				//int status = NativeMethods.ubrk_getRuleStatus(_breakIterator);
 				RuleStatus = ruleStatusVector.Max();
 			}

--- a/source/icu.net/RuleBasedBreakIterator.cs
+++ b/source/icu.net/RuleBasedBreakIterator.cs
@@ -1,5 +1,8 @@
-﻿using System;
+﻿// Copyright (c) 2013 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Icu
 {
@@ -19,7 +22,18 @@ namespace Icu
 		private IntPtr _breakIterator = IntPtr.Zero;
 
 		/// <summary>
-		/// Creates a BreakIterator with the given BreakIteratorType, Locale.
+		/// Default RuleStatus vector returns 0.
+		/// </summary>
+		protected readonly static int[] EmptyRuleStatusVector = new int[] { 0 };
+		protected readonly static Locale DefaultLocale = new Locale();
+
+		protected int _currentIndex = 0;
+		protected TextBoundary[] _textBoundaries = new TextBoundary[0];
+		protected string _text;
+		protected readonly Locale _locale = DefaultLocale;
+
+		/// <summary>
+		/// Creates a BreakIterator with the given BreakIteratorType and Locale.
 		/// </summary>
 		/// <param name="iteratorType">Break type.</param>
 		/// <param name="locale">The locale.</param>
@@ -29,8 +43,9 @@ namespace Icu
 		/// not desired <see cref="BreakIterator.GetBoundaries(BreakIterator.UBreakIteratorType, Locale, string, bool)"/>.
 		/// </remarks>
 		public RuleBasedBreakIterator(UBreakIteratorType iteratorType, Locale locale)
-			: base(locale)
+			: base()
 		{
+			_locale = locale;
 			_iteratorType = iteratorType;
 		}
 
@@ -38,14 +53,327 @@ namespace Icu
 		/// Creates a RuleBasedBreakIterator with the given rules.
 		/// </summary>
 		public RuleBasedBreakIterator(string rules)
-			: base(DefaultLocale)
+			: base()
 		{
 			_rules = rules;
 		}
 
+		/// <summary>
+		/// Gets all of the boundaries for the given text.
+		/// </summary>
+		public override int[] Boundaries
+		{
+			get { return _textBoundaries.Select(x => x.Offset).ToArray(); }
+		}
+
+		/// <summary>
+		/// Gets the locale for this BreakIterator.
+		/// </summary>
+		public override Locale Locale { get { return _locale; } }
+
+		/// <summary>
+		/// Gets the text being examined by this BreakIterator.
+		/// </summary>
+		public override string Text { get { return _text; } }
+
+		/// <summary>
+		/// Determine the most recently-returned text boundary.
+		/// Returns <see cref="DONE"/> if there are no boundaries left to return.
+		/// </summary>
+		public override int Current
+		{
+			get
+			{
+				if (string.IsNullOrEmpty(Text))
+					return 0;
+
+				return _textBoundaries[_currentIndex].Offset;
+			}
+		}
+
+		/// <summary>
+		/// Decrements the iterator and returns the previous boundary.
+		/// Returns DONE if the iterator moves past the first boundary.
+		/// </summary>
+		public override int MovePrevious()
+		{
+			// If we are trying to go into negative indices, return DONE.
+			if (_currentIndex == 0)
+			{
+				return DONE;
+			}
+
+			_currentIndex--;
+
+			return _textBoundaries[_currentIndex].Offset;
+		}
+
+		/// <summary>
+		/// Increments the iterator and returns the next boundary.
+		/// Returns DONE if there are no boundaries left to return.
+		/// </summary>
+		public override int MoveNext()
+		{
+			int nextIndex = _currentIndex + 1;
+
+			// If the next index is going to move this out of boundaries, do
+			// not incremement the index.
+			if (nextIndex >= Boundaries.Length)
+			{
+				return DONE;
+			}
+			else
+			{
+				_currentIndex = nextIndex;
+			}
+
+			return _textBoundaries[_currentIndex].Offset;
+		}
+
+		/// <summary>
+		/// Sets the iterator to the first boundary and returns it.
+		/// Returns DONE if there was no text set.
+		/// </summary>
+		public override int MoveFirst()
+		{
+			if (string.IsNullOrEmpty(Text))
+				return 0;
+
+			_currentIndex = 0;
+			return _textBoundaries[_currentIndex].Offset;
+		}
+
+		/// <summary>
+		/// Sets the iterator to the last boundary and returns the offset into
+		/// the text.
+		/// Returns DONE if there was no text set.
+		/// </summary>
+		public override int MoveLast()
+		{
+			if (Text == null)
+			{
+				return DONE;
+			}
+			else if (Text.Equals(string.Empty))
+			{
+				return 0;
+			}
+
+			_currentIndex = Boundaries.Length - 1;
+			return _textBoundaries[_currentIndex].Offset;
+		}
+
+		/// <summary>
+		/// Sets the iterator to refer to the first boundary position following
+		/// the specified position.
+		/// </summary>
+		/// <param name="offset">The position from which to begin searching for
+		/// a break position.</param>
+		/// <returns>The position of the first break after the current position.
+		/// The value returned is always greater than offset, or <see cref="BreakIterator.DONE"/>
+		/// </returns>
+		public override int MoveFollowing(int offset)
+		{
+			// if the offset passed in is already past the end of the text,
+			// just return DONE; if it's before the beginning, return the
+			// text's starting offset
+			if (Text == null || offset >= Text.Length)
+			{
+				MoveLast();
+				return MoveNext();
+			}
+			else if (offset < 0)
+			{
+				return MoveFirst();
+			}
+
+			if (offset == _textBoundaries[0].Offset)
+			{
+				_currentIndex = 0;
+				return MoveNext();
+			}
+			else if (offset == _textBoundaries[_textBoundaries.Length - 1].Offset)
+			{
+				_currentIndex = _textBoundaries.Length - 1;
+				return MoveNext();
+			}
+			else
+			{
+				int index = 1;
+				// We are guaranteed not to leave the array due to range test above
+				while (offset >= _textBoundaries[index].Offset)
+				{
+					index++;
+				}
+
+				_currentIndex = index;
+				return _textBoundaries[_currentIndex].Offset;
+			}
+		}
+
+		/// <summary>
+		/// Sets the iterator to refer to the last boundary position before the
+		/// specified position.
+		/// </summary>
+		/// <param name="offset">The position to begin searching for a break from.</param>
+		/// <returns>The position of the last boundary before the starting
+		/// position. The value returned is always smaller than the offset
+		/// or the value <see cref="BreakIterator.DONE"/></returns>
+		public override int MovePreceding(int offset)
+		{
+			if (Text == null || offset > Text.Length)
+			{
+				return MoveLast();
+			}
+			else if (offset < 0)
+			{
+				return MoveFirst();
+			}
+
+			// If the offset is less than the first boundary, return the first
+			// boundary. Else if, the offset is greater than the last boundary,
+			// return the last boundary.
+			// Otherwise, the offset is somewhere in the middle. So we start
+			// iterating through the boundaries until we get to a point where
+			// the current boundary we are at has a greater offset than the given
+			// one. So we return that.
+			if (_textBoundaries.Length == 0 || offset == _textBoundaries[0].Offset)
+			{
+				_currentIndex = 0;
+				return DONE;
+			}
+			else if (offset < _textBoundaries[0].Offset)
+			{
+				_currentIndex = 0;
+			}
+			else if (offset > _textBoundaries[_textBoundaries.Length - 1].Offset)
+			{
+				_currentIndex = _textBoundaries.Length - 1;
+			}
+			else
+			{
+				int index = 0;
+
+				while (index < _textBoundaries.Length
+					  && offset > _textBoundaries[index].Offset)
+				{
+					index++;
+				}
+
+				index--;
+
+				_currentIndex = index;
+			}
+
+			return _textBoundaries[_currentIndex].Offset;
+		}
+
+		/// <summary>
+		/// Returns true if the specified position is a boundary position and
+		/// false, otherwise. In addition, it leaves the iterator pointing to
+		/// the first boundary position at or after "offset".
+		/// </summary>
+		public override bool IsBoundary(int offset)
+		{
+			// When the text is null or empty, there are no boundaries
+			// The current offset is already at BreakIterator.DONE.
+			if (_textBoundaries.Length == 0)
+			{
+				return false;
+			}
+
+			// the beginning index of the iterator is always a boundary position by definition
+			if (offset == 0)
+			{
+				MoveFirst(); // For side effects on current position, tag values.
+				return true;
+			}
+
+			int lastOffset = _textBoundaries.Last().Offset;
+
+			if (offset == lastOffset)
+			{
+				MoveLast();
+				return true;
+			}
+
+			// out-of-range indexes are never boundary positions
+			if (offset < 0)
+			{
+				MoveFirst();
+				return false;
+			}
+
+			if (offset > lastOffset)
+			{
+				MoveLast();
+				return false;
+			}
+
+			var current = MoveFirst();
+
+			while (current != DONE)
+			{
+				if (current == offset)
+					return true;
+
+				if (current > offset)
+					return false;
+
+				current = MoveNext();
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Returns the status tag from the break rule that determined the
+		/// current position.  For break iterator types that do not support a
+		/// rule status, a default value of 0 is returned.
+		/// </summary>
+		/// <remarks>
+		/// For more information, see
+		/// http://userguide.icu-project.org/boundaryanalysis#TOC-Rule-Status-Values
+		/// </remarks>
+		public override int GetRuleStatus()
+		{
+			if (string.IsNullOrEmpty(Text))
+				return 0;
+
+			return _textBoundaries[_currentIndex].RuleStatus;
+		}
+
+		/// <summary>
+		/// Get the statuses from the break rules that determined the most
+		/// recently returned break position.
+		///
+		/// The values appear in the rule source within brackets, {123}, for
+		/// example.  The default status value for rules that do not explicitly
+		/// provide one is zero.
+		///
+		/// For word break iterators, the possible values are defined in enum
+		/// <see cref="BreakIterator.UWordBreak"/>.
+		/// </summary>
+		/// <remarks>
+		/// For more information, see
+		/// http://userguide.icu-project.org/boundaryanalysis#TOC-Rule-Status-Values
+		/// </remarks>
+		public override int[] GetRuleStatusVector()
+		{
+			if (string.IsNullOrEmpty(Text))
+				return EmptyRuleStatusVector;
+
+			return _textBoundaries[_currentIndex].RuleStatusVector;
+		}
+
 		public override void SetText(string text)
 		{
-			base.SetText(text);
+			if (text == null)
+			{
+				throw new ArgumentNullException("text");
+			}
+
+			_text = text;
 
 			if (string.IsNullOrEmpty(Text))
 			{
@@ -229,5 +557,31 @@ namespace Icu
 		}
 
 		#endregion
+
+		/// <summary>
+		/// Keeps track of each text boundary by containing its offset,
+		/// and the set of rules used to obtain that boundary.
+		/// </summary>
+		protected struct TextBoundary
+		{
+			public readonly int Offset;
+			public readonly int RuleStatus;
+			public readonly int[] RuleStatusVector;
+
+			public TextBoundary(int index, int[] ruleStatusVector)
+			{
+				Offset = index;
+				RuleStatusVector = ruleStatusVector;
+
+				// According to the documentation, in the event that there are
+				// multiple values in ubrk_getRuleStatusVec(), a call to
+				// ubrk_getRuleStatus() will return the numerically largest
+				// from the vector.  We are saving a PInvoke by finding the max
+				// value.
+				// http://userguide.icu-project.org/boundaryanalysis#TOC-Rule-Status-Values 
+				//int status = NativeMethods.ubrk_getRuleStatus(_breakIterator);
+				RuleStatus = ruleStatusVector.Max();
+			}
+		}
 	}
 }

--- a/source/icu.net/RuleBasedBreakIterator.cs
+++ b/source/icu.net/RuleBasedBreakIterator.cs
@@ -526,7 +526,7 @@ namespace Icu
 		/// for more information.
 		/// </summary>
 		/// <param name="disposing"></param>
-		protected virtual void Dispose(bool disposing)
+		protected override void Dispose(bool disposing)
 		{
 			if (!_disposingValue)
 			{
@@ -548,12 +548,6 @@ namespace Icu
 		~RuleBasedBreakIterator()
 		{
 			Dispose(false);
-		}
-
-		public override void Dispose()
-		{
-			Dispose(true);
-			GC.SuppressFinalize(this);
 		}
 
 		#endregion

--- a/source/icu.net/icu.net.csproj
+++ b/source/icu.net/icu.net.csproj
@@ -135,6 +135,7 @@
     <Compile Include="ParseError.cs" />
     <Compile Include="Collation\RuleBasedCollator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RuleBasedBreakIterator.cs" />
     <Compile Include="VersionInfo.cs" />
     <Compile Include="IcuWrapper.cs" />
     <Compile Include="NativeMethods.cs" />
@@ -191,14 +192,12 @@
     <Copy SourceFiles="$(ProjectDir)NuGetAssets/icu.net.nuspec" DestinationFolder="$(SolutionDir)NuGetBuild" />
     <Copy SourceFiles="@(IcuDotNetFiles)" DestinationFolder="$(SolutionDir)NuGetBuild/lib/net40" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(SolutionDir)NuGetBuild" MetadataAssembly="$(TargetPath)" Version="$(GitVersion_NuGetVersion)" />
-    <Message Importance="High" Text="Created nuget package version $(GitVersion_NuGetVersion) ($(GitVersion_FullSemVer))"/>
+    <Message Importance="High" Text="Created nuget package version $(GitVersion_NuGetVersion) ($(GitVersion_FullSemVer))" />
   </Target>
   <PropertyGroup>
     <PreBuildEvent />
   </PropertyGroup>
-  <ItemGroup>
-    <Folder Include="NuGetAssets" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="..\packages\GitVersionTask.4.0.0-beta0009\build\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.4.0.0-beta0009\build\GitVersionTask.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/source/icu.net/icu.net.csproj
+++ b/source/icu.net/icu.net.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Locale.cs" />
     <Compile Include="ParseError.cs" />
     <Compile Include="Collation\RuleBasedCollator.cs" />
+    <Compile Include="ParseErrorException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RuleBasedBreakIterator.cs" />
     <Compile Include="VersionInfo.cs" />


### PR DESCRIPTION
Adds the following methods to BreakIterator that also exist in [icu::BreakIterator](http://icu-project.org/apiref/icu4c/classicu_1_1BreakIterator.html).  Adds tests as well.

```csharp
public class BreakIterator 
{
    /// <summary>
    /// Creates a BreakIterator with the given BreakIteratorType, Locale
    /// and sets the initial text.
    /// </summary>
    protected BreakIterator(UBreakIteratorType iteratorType, Locale locale, string text);

    /// <summary>
    /// Creates a BreakIterator with the given BreakIteratorType, Locale
    /// and sets the initial text.
    /// </summary>
    protected BreakIterator(UBreakIteratorType iteratorType, Locale locale, string text, bool includeSpacesAndPunctuation);

    /// <summary>
    /// Increments the iterator and returns the next Boundary.
    /// Returns null if there are no boundaries left to return.
    /// </summary>
    public virtual Boundary Next  { get; }

    /// <summary>
    /// The current Boundary.
    /// Returns null if there are no boundaries left to return.
    /// </summary>
    public virtual Boundary Current { get; }

    /// <summary>
    /// Decrements the iterator and returns the previous Boundary.
    /// Returns null if the iterator moves past the first Boundary.
    /// </summary>
    public virtual Boundary Previous { get; }

    /// <summary>
    /// Sets the iterator to the first Boundary and returns it.
    /// Returns null if there was no text set.
    /// </summary>
    public virtual Boundary First { get; }

    /// <summary>
    /// Sets the iterator to the last Boundary and returns it.
    /// Returns null if there was no text set.
    /// </summary>
    public virtual Boundary Last { get; }

    /// <summary>
    /// Gets all of the Boundaries for the given text.
    /// Returns Boundary[0] if the text was empty or null.
    /// </summary>
    public virtual Boundary[] Boundaries { get; protected set; }

    /// <summary>
    /// Gets the text being examined by this BreakIterator.
    /// </summary>
    public virtual string Text { get; }
    
    /// <summary>
    /// Sets the current text being examined to the given text.
    /// Sets the current index back to the first element.
    /// </summary>
    public virtual void SetText(string text);

    /// <summary>
    /// Gets the locale for this BreakIterator.
    /// </summary>
    public Locale Locale { get; }

    public static BreakIterator CreateCharacterInstance(Locale locale, string text);
    public static BreakIterator CreateWordInstance(Locale locale, string text, bool includeSpacesAndPunctuation);
    public static BreakIterator CreateLineInstance(Locale locale, string text);
    public static BreakIterator CreateSentenceInstance(Locale locale, string text);
}
```

#24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/25)
<!-- Reviewable:end -->
