### PR TITLE
Fix CS1591 warnings

### DIFF
--- a/source/icu.net/Boundary.cs
+++ b/source/icu.net/Boundary.cs
@@ -17,11 +17,11 @@ namespace Icu
 		/// </summary>
 		public readonly int End;
 
-        /// <summary>
-        /// Creates a boundary with the specified start and end. The word would lie
-        /// between indices x, Start &lt;= x &lt; End
-        /// </summary>
-        public Boundary(int start, int end)
+		/// <summary>
+		/// Creates a boundary with the specified start and end. The word would
+		/// lie between indices x, Start &lt;= x &lt; End
+		/// </summary>
+		public Boundary(int start, int end)
 		{
 			if (start > end)
 			{
@@ -32,20 +32,34 @@ namespace Icu
 			End = end;
 		}
 
+		/// <summary>
+		/// Checks to see whether the given object is a Boundary with the same
+		/// start and end positions.
+		/// </summary>
+		/// <param name="obj"></param>
+		/// <returns>true if the obj is equal, false otherwise.</returns>
 		public override bool Equals(object obj)
 		{
 			var compared = obj as Boundary;
 
-			return compared != null 
-				&& Start == compared.Start 
+			return compared != null
+				&& Start == compared.Start
 				&& End == compared.End;
 		}
 
+		/// <summary>
+		/// Serves the default hash function.
+		/// </summary>
+		/// <returns></returns>
 		public override int GetHashCode()
 		{
 			return base.GetHashCode();
 		}
 
+		/// <summary>
+		/// Returns a string with the Start and End positions of the object.
+		/// </summary>
+		/// <returns></returns>
 		public override string ToString()
 		{
 			return string.Format("Start: [{0}], End: [{1}]", Start, End);

--- a/source/icu.net/BreakIterator.cs
+++ b/source/icu.net/BreakIterator.cs
@@ -32,6 +32,14 @@ namespace Icu
 			//TITLE
 		}
 
+		/// <summary>
+		/// Enum constants for the word break tags returned by <see cref="GetRuleStatus"/>
+		/// and <see cref="GetRuleStatusVector"/>.
+		/// A range of values is defined for each category of word, to allow for
+		/// further subdivisions of a category in future releases.
+		/// Applications should check for tag values falling within the range,
+		/// rather than for single individual values.
+		/// </summary>
 		public enum UWordBreak
 		{
 			/// <summary>
@@ -78,19 +86,64 @@ namespace Icu
 			IDEO_LIMIT     = 500,
 		}
 
+		/// <summary>
+		/// Enum constants for the line break tags returned by <see cref="GetRuleStatus"/>
+		/// and <see cref="GetRuleStatusVector"/>.
+		/// A range of values is defined for each category of word, to allow for
+		/// further subdivisions of a category in future releases.
+		/// Applications should check for tag values falling within the range,
+		/// rather than for single individual values.
+		/// </summary>
 		public enum ULineBreakTag
 		{
+			/// <summary>
+			/// Tag value for soft line breaks, positions at which a line break
+			/// is acceptable but not required
+			/// </summary>
 			SOFT            = 0,
+			/// <summary>
+			/// Upper bound for soft line breaks.
+			/// </summary>
 			SOFT_LIMIT      = 100,
+			/// <summary>
+			/// Tag value for a hard, or mandatory line break
+			/// </summary>
 			HARD            = 100,
+			/// <summary>
+			/// Upper bound for hard line breaks.
+			/// </summary>
 			HARD_LIMIT      = 200,
 		}
 
+		/// <summary>
+		/// Enum constants for the sentence break tags returned by <see cref="GetRuleStatus"/>
+		/// and <see cref="GetRuleStatusVector"/>.
+		/// A range of values is defined for each category of sentence, to allow
+		/// for further subdivisions of a category in future releases.
+		/// Applications should check for tag values falling within the range,
+		/// rather than for single individual values.
+		/// </summary>
 		public enum USentenceBreakTag
 		{
+			/// <summary>
+			/// Tag value for for sentences  ending with a sentence terminator
+			/// ('.', '?', '!', etc.) character, possibly followed by a
+			/// hard separator (CR, LF, PS, etc.)
+			/// </summary>
 			TERM       = 0,
+			/// <summary>
+			/// Upper bound for tags for sentences ended by sentence terminators.
+			/// </summary>
 			TERM_LIMIT = 100,
+			/// <summary>
+			/// ag value for for sentences that do not contain an ending
+			/// sentence terminator ('.', '?', '!', etc.) character, but
+			/// are ended only by a hard separator (CR, LF, PS, etc.) or end of input.
+			/// </summary>
 			SEP        = 100,
+			/// <summary>
+			/// Upper bound for tags for sentences ended by a separator.
+			/// </summary>
 			SEP_LIMIT  = 200,
 		}
 
@@ -237,7 +290,6 @@ namespace Icu
 		/// Creates a BreakIterator that splits on lines for the given locale.
 		/// </summary>
 		/// <param name="locale">The locale.</param>
-		/// <param name="text">The initial text.</param>
 		public static BreakIterator CreateLineInstance(Locale locale)
 		{
 			return new RuleBasedBreakIterator(UBreakIteratorType.LINE, locale);
@@ -247,7 +299,6 @@ namespace Icu
 		/// Creates a BreakIterator that splits on sentences for the given locale.
 		/// </summary>
 		/// <param name="locale">The locale.</param>
-		/// <param name="text">The initial text.</param>
 		public static BreakIterator CreateSentenceInstance(Locale locale)
 		{
 			return new RuleBasedBreakIterator(UBreakIteratorType.SENTENCE, locale);
@@ -288,6 +339,8 @@ namespace Icu
 		/// <summary>
 		/// Gets word boundaries for given text.
 		/// </summary>
+		/// <param name="locale">The locale to use</param>
+		/// <param name="text">The input text</param>
 		/// <param name="includeSpacesAndPunctuation">
 		/// ICU's UBreakIteratorType.WORD analysis considers spaces and
 		/// punctuation as boundaries for words. Set parameter to true if all
@@ -302,6 +355,8 @@ namespace Icu
 		/// <summary>
 		/// Gets word boundaries for given text.
 		/// </summary>
+		/// <param name="locale">The locale to use</param>
+		/// <param name="text">The input text</param>
 		/// <param name="includeSpacesAndPunctuation">
 		/// ICU's UBreakIteratorType.WORD analysis considers spaces and
 		/// punctuation as boundaries for words. Set parameter to true if all
@@ -378,6 +433,11 @@ namespace Icu
 			GC.SuppressFinalize(this);
 		}
 
+		/// <summary>
+		/// Releases the resources used by BreakIterator.
+		/// </summary>
+		/// <param name="disposing">true to release managed and unmanaged
+		/// resources; false to release only unmanaged resources.</param>
 		protected virtual void Dispose(bool disposing) { }
 	}
 }

--- a/source/icu.net/BreakIterator.cs
+++ b/source/icu.net/BreakIterator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 SIL International
+﻿// Copyright (c) 2013 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
@@ -126,7 +126,7 @@ namespace Icu
 		public enum USentenceBreakTag
 		{
 			/// <summary>
-			/// Tag value for for sentences  ending with a sentence terminator
+			/// Tag value for sentences ending with a sentence terminator
 			/// ('.', '?', '!', etc.) character, possibly followed by a
 			/// hard separator (CR, LF, PS, etc.)
 			/// </summary>
@@ -136,7 +136,7 @@ namespace Icu
 			/// </summary>
 			TERM_LIMIT = 100,
 			/// <summary>
-			/// ag value for for sentences that do not contain an ending
+			/// Tag value for sentences that do not contain an ending
 			/// sentence terminator ('.', '?', '!', etc.) character, but
 			/// are ended only by a hard separator (CR, LF, PS, etc.) or end of input.
 			/// </summary>

--- a/source/icu.net/Character.cs
+++ b/source/icu.net/Character.cs
@@ -6,11 +6,16 @@ using System.Runtime.InteropServices;
 
 namespace Icu
 {
+	/// <summary>
+	/// Provides access to Unicode Character Database.
+	/// In addition to raw property values, some convenience functions calculate
+	/// derived properties.
+	/// </summary>
 	public static class Character
 	{
 		/// <summary>
 		/// Defined in ICU uchar.h
-		/// http://oss.software.ibm.com/icu/apiref/uchar_8h-source.html#l00158
+		/// http://icu-project.org/apiref/icu4c/uchar_8h.html
 		/// </summary>
 		public enum UProperty
 		{
@@ -22,118 +27,367 @@ namespace Icu
 			debuggers display ALPHABETIC as the symbolic name for 0,
 			rather than BINARY_START.  Likewise for other *_START
 			identifiers. */
-
+			/// <summary>
+			/// Same as u_isUAlphabetic, different from u_isalpha.
+			/// Lu+Ll+Lt+Lm+Lo+Nl+Other_Alphabetic
+			/// </summary>
 			ALPHABETIC = 0,
+			/// <summary>First constant for binary Unicode properties.</summary>
 			BINARY_START = ALPHABETIC,
+			/// <summary>0-9 A-F a-f</summary>
 			ASCII_HEX_DIGIT = 1,
+			/// <summary>Format controls which have specific functions in the Bidi Algorithm.</summary>
 			BIDI_CONTROL = 2,
+			/// <summary>
+			/// Characters that may change display in RTL text. Same as
+			/// u_isMirrored. See Bidi Algorithm, UTR 9.
+			/// </summary>
 			BIDI_MIRRORED = 3,
+			/// <summary>Variations of dashes.</summary>
 			DASH = 4,
+			/// <summary>Ignorable in most processing.</summary>
+			/// <example>&lt;2060..206F, FFF0..FFFB, E0000..E0FFF&gt;+Other_Default_Ignorable_Code_Point+(Cf+Cc+Cs-White_Space)</example>
 			DEFAULT_IGNORABLE_CODE_POINT = 5,
+			/// <summary>The usage of deprecated characters is strongly discouraged.</summary>
 			DEPRECATED = 6,
+			/// <summary>
+			/// Characters that linguistically modify the meaning of another
+			/// character to which they apply.
+			/// </summary>
 			DIACRITIC = 7,
+			/// <summary>
+			/// Extend the value or shape of a preceding alphabetic character,
+			/// e.g., length and iteration marks.
+			/// </summary>
 			EXTENDER = 8,
+			/// <summary>CompositionExclusions.txt+Singleton Decompositions+ Non-Starter Decompositions.</summary>
 			FULL_COMPOSITION_EXCLUSION = 9,
+			/// <summary>For programmatic determination of grapheme cluster boundaries.</summary>
+			/// <example>[0..10FFFF]-Cc-Cf-Cs-Co-Cn-Zl-Zp-Grapheme_Link-Grapheme_Extend-CGJ</example>
 			GRAPHEME_BASE = 10,
+			/// <summary>For programmatic determination of grapheme cluster boundaries.</summary>
+			/// <example>Me+Mn+Mc+Other_Grapheme_Extend-Grapheme_Link-CGJ</example>
 			GRAPHEME_EXTEND = 11,
+			/// <summary>For programmatic determination of grapheme cluster boundaries.</summary>
 			GRAPHEME_LINK = 12,
+			/// <summary>Characters commonly used for hexadecimal numbers.</summary>
 			HEX_DIGIT = 13,
+			/// <summary>
+			/// Dashes used to mark connections between pieces of words,plus the
+			/// Katakana middle dot.
+			/// </summary>
 			HYPHEN = 14,
+			/// <summary>
+			/// Characters that can continue an identifier.
+			/// DerivedCoreProperties.txt also says "NOTE: Cf characters should
+			/// be filtered out."
+			/// </summary>
+			/// <example>ID_Start+Mn+Mc+Nd+Pc</example>
 			ID_CONTINUE = 15,
+			/// <summary>Characters that can start an identifier.</summary>
+			/// <example>Lu+Ll+Lt+Lm+Lo+Nl</example>
 			ID_START = 16,
+			/// <summary>CJKV ideographs.</summary>
 			IDEOGRAPHIC = 17,
+			/// <summary>For programmatic determination of Ideographic Description Sequences.</summary>
 			IDS_BINARY_OPERATOR = 18,
+			/// <summary>For programmatic determination of Ideographic Description Sequences.</summary>
 			IDS_TRINARY_OPERATOR = 19,
+			/// <summary>Format controls for cursive joining and ligation.</summary>
 			JOIN_CONTROL = 20,
+			/// <summary>
+			/// Characters that do not use logical order and require special
+			/// handling in most processing.
+			/// </summary>
 			LOGICAL_ORDER_EXCEPTION = 21,
+			/// <summary>Same as u_isULowercase, different from u_islower.</summary>
+			/// <example>Ll+Other_Lowercase</example>
 			LOWERCASE = 22,
+			/// <summary>Sm+Other_Math</summary>
 			MATH = 23,
+			/// <summary>Code points that are explicitly defined as illegal for the encoding of characters.</summary>
 			NONCHARACTER_CODE_POINT = 24,
+			/// <summary>Binary property Quotation_Mark.</summary>
 			QUOTATION_MARK = 25,
+			/// <summary>For programmatic determination of Ideographic Description Sequences.</summary>
 			RADICAL = 26,
+			/// <summary>
+			/// Characters with a "soft dot", like i or j. An accent placed on
+			/// these characters causes the dot to disappear.
+			/// </summary>
 			SOFT_DOTTED = 27,
+			/// <summary>Punctuation characters that generally mark the end of textual units.</summary>
 			TERMINAL_PUNCTUATION = 28,
+			/// <summary>For programmatic determination of Ideographic Description Sequences.</summary>
 			UNIFIED_IDEOGRAPH = 29,
+			/// <summary>Same as u_isUUppercase, different from u_isupper. Lu+Other_Uppercase</summary>
 			UPPERCASE = 30,
+			/// <summary>
+			/// Same as u_isUWhiteSpace, different from u_isspace and
+			/// u_isWhitespace. Space characters+TAB+CR+LF-ZWSP-ZWNBSP
+			/// </summary>
 			WHITE_SPACE = 31,
+			/// <summary>ID_Continue modified to allow closure under normalization forms NFKC and NFKD.</summary>
 			XID_CONTINUE = 32,
+			/// <summary>ID_Start modified to allow closure under normalization forms NFKC and NFKD.</summary>
 			XID_START = 33,
+			/// <summary>
+			/// Either the source of a case mapping or in the target of a case
+			/// mapping. Not the same as the general category Cased_Letter.
+			/// </summary>
 			CASE_SENSITIVE = 34,
+			/// <summary>Sentence Terminal. Used in UAX #29: Text Boundaries (http://www.unicode.org/reports/tr29/)</summary>
 			S_TERM = 35,
+			/// <summary>
+			/// ICU-specific property for characters that are inert under NFD,
+			/// i.e., they do not interact with adjacent characters. See the
+			/// documentation for the Normalizer2 class and the
+			/// Normalizer2::isInert() method.
+			/// http://www.icu-project.org/apiref/icu4c/classicu_1_1Normalizer2.html
+			/// </summary>
 			VARIATION_SELECTOR = 36,
+			/// <summary>
+			/// ICU-specific property for characters that are inert under NFD,
+			/// i.e., they do not interact with adjacent characters. See the
+			/// documentation for the Normalizer2 class and the
+			/// Normalizer2::isInert() method.
+			/// http://www.icu-project.org/apiref/icu4c/classicu_1_1Normalizer2.html
+			/// </summary>
 			NFD_INERT = 37,
+			/// <summary>
+			/// ICU-specific property for characters that are inert under NFKD,
+			/// i.e., they do not interact with adjacent characters. See the
+			/// documentation for the Normalizer2 class and the
+			/// Normalizer2::isInert() method.
+			/// http://www.icu-project.org/apiref/icu4c/classicu_1_1Normalizer2.html
+			/// </summary>
 			NFKD_INERT = 38,
+			/// <summary>
+			/// ICU-specific property for characters that are inert under NFC,
+			/// i.e., they do not interact with adjacent characters. See the
+			/// documentation for the Normalizer2 class and the
+			/// Normalizer2::isInert() method.
+			/// http://www.icu-project.org/apiref/icu4c/classicu_1_1Normalizer2.html
+			/// </summary>
 			NFC_INERT = 39,
+			/// <summary>
+			/// ICU-specific property for characters that are inert under NFKC,
+			/// i.e., they do not interact with adjacent characters. See the
+			/// documentation for the Normalizer2 class and the
+			/// Normalizer2::isInert() method.
+			/// http://www.icu-project.org/apiref/icu4c/classicu_1_1Normalizer2.html
+			/// </summary>
 			NFKC_INERT = 40,
+			/// <summary>
+			/// ICU-specific property for characters that are starters in terms
+			/// of Unicode normalization and combining character sequences. They
+			/// have ccc=0 and do not occur in non-initial position of the
+			/// canonical decomposition of any character (like a-umlaut in NFD
+			/// and a Jamo T in an NFD(Hangul LVT)). ICU uses this property for
+			/// segmenting a string for generating a set of canonically
+			/// equivalent strings, e.g. for canonical closure while processing
+			/// collation tailoring rules.
+			/// </summary>
 			SEGMENT_STARTER = 41,
+			/// <summary>See UAX #31 Identifier and Pattern Syntax (http://www.unicode.org/reports/tr31/)</summary>
 			PATTERN_SYNTAX = 42,
+			/// <summary>See UAX #31 Identifier and Pattern Syntax (http://www.unicode.org/reports/tr31/)</summary>
 			PATTERN_WHITE_SPACE = 43,
+			/// <summary>
+			/// Implemented according to the UTS #18 Annex C Standard
+			/// Recommendation. See the uchar.h file documentation.
+			/// http://icu-project.org/apiref/icu4c/uchar_8h.html
+			/// </summary>
 			POSIX_ALNUM = 44,
+			/// <summary>
+			/// Implemented according to the UTS #18 Annex C Standard
+			/// Recommendation. See the uchar.h file documentation.
+			/// http://icu-project.org/apiref/icu4c/uchar_8h.html
+			/// </summary>
 			POSIX_BLANK = 45,
+			/// <summary>
+			/// Implemented according to the UTS #18 Annex C Standard
+			/// Recommendation. See the uchar.h file documentation.
+			/// http://icu-project.org/apiref/icu4c/uchar_8h.html
+			/// </summary>
 			POSIX_GRAPH = 46,
+			/// <summary>
+			/// Implemented according to the UTS #18 Annex C Standard
+			/// Recommendation. See the uchar.h file documentation.
+			/// http://icu-project.org/apiref/icu4c/uchar_8h.html
+			/// </summary>
 			POSIX_PRINT = 47,
+			/// <summary>
+			/// Implemented according to the UTS #18 Annex C Standard
+			/// Recommendation. See the uchar.h file documentation.
+			/// http://icu-project.org/apiref/icu4c/uchar_8h.html
+			/// </summary>
 			POSIX_XDIGIT = 48,
+			/// <summary>For Lowercase, Uppercase and Titlecase characters.</summary>
 			CASED = 49,
+			/// <summary>Used in context-sensitive case mappings.</summary>
 			CASE_IGNORABLE = 50,
+			/// <summary>Binary property Changes_When_Lowercased.</summary>
 			CHANGES_WHEN_LOWERCASED = 51,
+			/// <summary>Binary property Changes_When_Uppercased.</summary>
 			CHANGES_WHEN_UPPERCASED = 52,
+			/// <summary>Binary property Changes_When_Titlecased.</summary>
 			CHANGES_WHEN_TITLECASED = 53,
+			/// <summary>Binary property Changes_When_Casefolded.</summary>
 			CHANGES_WHEN_CASEFOLDED = 54,
+			/// <summary>Binary property Changes_When_Casemapped.</summary>
 			CHANGES_WHEN_CASEMAPPED = 55,
+			/// <summary>Binary property Changes_When_NFKC_Casefolded.</summary>
 			CHANGES_WHEN_NFKC_CASEFOLDED = 56,
+			/// <summary>One more than the last constant for binary Unicode properties.</summary>
+			[Obsolete("ICU 58 The numeric value may change over time, see ICU ticket #12420.")]
 			BINARY_LIMIT = 57,
 
+			/// <summary>Same as u_charDirection, returns UCharDirection values.</summary>
 			BIDI_CLASS = 0x1000,
+			/// <summary>First constant for enumerated/integer Unicode properties.</summary>
 			INT_START = BIDI_CLASS,
+			/// <summary>Same as ublock_getCode, returns UBlockCode values.</summary>
 			BLOCK = 0x1001,
+			/// <summary>Same as u_getCombiningClass, returns 8-bit numeric values.</summary>
 			CANONICAL_COMBINING_CLASS = 0x1002,
+			/// <summary>Returns UDecompositionType values.</summary>
 			DECOMPOSITION_TYPE = 0x1003,
+			/// <summary>See http://www.unicode.org/reports/tr11/ Returns UEastAsianWidth values.</summary>
 			EAST_ASIAN_WIDTH = 0x1004,
+			/// <summary>Same as u_charType, returns UCharCategory values.</summary>
 			GENERAL_CATEGORY = 0x1005,
+			/// <summary>Returns UJoiningGroup values.</summary>
 			JOINING_GROUP = 0x1006,
+			/// <summary>Returns UJoiningType values.</summary>
 			JOINING_TYPE = 0x1007,
+			/// <summary>Returns ULineBreak values.</summary>
 			LINE_BREAK = 0x1008,
+			/// <summary>Returns UNumericType values.</summary>
 			NUMERIC_TYPE = 0x1009,
+			/// <summary>Same as uscript_getScript, returns UScriptCode values.</summary>
 			SCRIPT = 0x100A,
+			/// <summary>Returns UHangulSyllableType values.</summary>
 			HANGUL_SYLLABLE_TYPE = 0x100B,
+			/// <summary>Returns UNormalizationCheckResult values.</summary>
 			NFD_QUICK_CHECK = 0x100C,
+			/// <summary>Returns UNormalizationCheckResult values.</summary>
 			NFKD_QUICK_CHECK = 0x100D,
+			/// <summary>Returns UNormalizationCheckResult values.</summary>
 			NFC_QUICK_CHECK = 0x100E,
+			/// <summary>Returns UNormalizationCheckResult values.</summary>
 			NFKC_QUICK_CHECK = 0x100F,
+			/// <summary>
+			/// ICU-specific property for the ccc of the first code point of the
+			/// decomposition, or lccc(c)=ccc(NFD(c)[0]). Useful for checking
+			/// for canonically ordered text; see UNORM_FCD and
+			/// http://www.unicode.org/notes/tn5/#FCD . Returns 8-bit numeric
+			/// values like UCHAR_CANONICAL_COMBINING_CLASS.
+			/// </summary>
 			LEAD_CANONICAL_COMBINING_CLASS = 0x1010,
+			/// <summary>
+			/// ICU-specific property for the ccc of the last code point of the
+			/// decomposition, or tccc(c)=ccc(NFD(c)[last]). Useful for checking
+			/// for canonically ordered text; see UNORM_FCD and
+			/// http://www.unicode.org/notes/tn5/#FCD . Returns 8-bit numeric
+			/// values like UCHAR_CANONICAL_COMBINING_CLASS.
+			/// </summary>
 			TRAIL_CANONICAL_COMBINING_CLASS = 0x1011,
+			/// <summary>
+			/// Used in UAX #29: Text Boundaries (http://www.unicode.org/reports/tr29/)
+			/// Returns UGraphemeClusterBreak values.
+			/// </summary>
 			GRAPHEME_CLUSTER_BREAK = 0x1012,
+			/// <summary>
+			/// Used in UAX #29: Text Boundaries (http://www.unicode.org/reports/tr29/)
+			/// Returns USentenceBreak values
+			/// </summary>
 			SENTENCE_BREAK = 0x1013,
+			/// <summary>
+			/// Used in UAX #29: Text Boundaries (http://www.unicode.org/reports/tr29/)
+			/// Returns UWordBreakValues values.
+			/// </summary>
 			WORD_BREAK = 0x1014,
+			/// <summary>One more than the last constant for enumerated/integer Unicode properties.</summary>
+			[Obsolete("ICU 58 The numeric value may change over time, see ICU ticket #12420.")]
 			INT_LIMIT = 0x1015,
 
+			/// <summary>
+			/// This is the General_Category property returned as a bit mask.
+			/// When used in u_getIntPropertyValue(c), same as
+			/// U_MASK(u_charType(c)), returns bit masks for UCharCategory
+			/// values where exactly one bit is set. When used with
+			/// u_getPropertyValueName() and u_getPropertyValueEnum(), a
+			/// multi-bit mask is used for sets of categories like "Letters".
+			/// Mask values should be cast to uint32_t.
+			/// http://icu-project.org/apiref/icu4c/uchar_8h.html#a3f694e48867909fbe555586f2b3565be
+			/// </summary>
 			GENERAL_CATEGORY_MASK = 0x2000,
+			/// <summary>First constant for bit-mask Unicode properties.</summary>
 			MASK_START = GENERAL_CATEGORY_MASK,
+			/// <summary>One more than the last constant for bit-mask Unicode properties.</summary>
+			[Obsolete("ICU 58 The numeric value may change over time, see ICU ticket #12420.")]
 			MASK_LIMIT = 0x2001,
 
+			/// <summary>Corresponds to u_getNumericValue.</summary>
 			NUMERIC_VALUE = 0x3000,
+			/// <summary>First constant for double Unicode properties.</summary>
 			DOUBLE_START = NUMERIC_VALUE,
+			/// <summary>One more than the last constant for double Unicode properties.</summary>
+			[Obsolete("ICU 58 The numeric value may change over time, see ICU ticket #12420.")]
 			DOUBLE_LIMIT = 0x3001,
 
+			/// <summary>Corresponds to u_charAge.</summary>
 			AGE = 0x4000,
+			/// <summary>First constant for string Unicode properties.</summary>
 			STRING_START = AGE,
+			/// <summary>Corresponds to u_charMirror.</summary>
 			BIDI_MIRRORING_GLYPH = 0x4001,
+			/// <summary>Corresponds to u_strFoldCase in ustring.h (http://icu-project.org/apiref/icu4c/ustring_8h.html).</summary>
 			CASE_FOLDING = 0x4002,
+			/// <summary>Corresponds to u_getISOComment.</summary>
+			[Obsolete("ICU 49")]
 			ISO_COMMENT = 0x4003,
+			/// <summary>Corresponds to u_strToLower in ustring.h (http://icu-project.org/apiref/icu4c/ustring_8h.html).</summary>
 			LOWERCASE_MAPPING = 0x4004,
+			/// <summary>Corresponds to u_charName.</summary>
 			NAME = 0x4005,
+			/// <summary>Corresponds to u_foldCase.</summary>
 			SIMPLE_CASE_FOLDING = 0x4006,
+			/// <summary> Corresponds to u_tolower.</summary>
 			SIMPLE_LOWERCASE_MAPPING = 0x4007,
+			/// <summary> Corresponds to u_totitle.</summary>
 			SIMPLE_TITLECASE_MAPPING = 0x4008,
+			/// <summary> Corresponds to u_toupper.</summary>
 			SIMPLE_UPPERCASE_MAPPING = 0x4009,
+			/// <summary>Corresponds to u_strToTitle in ustring.h  (http://icu-project.org/apiref/icu4c/ustring_8h.html).</summary>
 			TITLECASE_MAPPING = 0x400A,
+			/// <summary>
+			/// This property is of little practical value. Beginning with
+			/// ICU 49, ICU APIs return an empty string for this property.
+			/// Corresponds to u_charName(U_UNICODE_10_CHAR_NAME).
+			/// </summary>
+			[Obsolete("ICU 49")]
 			UNICODE_1_NAME = 0x400B,
+			/// <summary>Corresponds to u_strToUpper in ustring.h (http://icu-project.org/apiref/icu4c/ustring_8h.html).</summary>
 			UPPERCASE_MAPPING = 0x400C,
+			/// <summary>One more than the last constant for string Unicode properties.</summary>
+			[Obsolete("ICU 58 The numeric value may change over time, see ICU ticket #12420.")]
 			STRING_LIMIT = 0x400D,
+			/// <summary>
+			/// Some characters are commonly used in multiple scripts. For more
+			/// information, see UAX #24: http://www.unicode.org/reports/tr24/.
+			/// Corresponds to uscript_hasScript and uscript_getScriptExtensions
+			/// in uscript.h. http://icu-project.org/apiref/icu4c/uscript_8h.html
+			/// </summary>
 			SCRIPT_EXTENSIONS = 0x7000,
+			/// <summary>First constant for Unicode properties with unusual value types</summary>
 			OTHER_PROPERTY_START = SCRIPT_EXTENSIONS,
+			/// <summary>One more than the last constant for Unicode properties with unusual value types.</summary>
+			[Obsolete("ICU 58 The numeric value may change over time, see ICU ticket #12420.")]
 			OTHER_PROPERTY_LIMIT = 0x7001,
-			INVALID_CODE  =  -1
+			/// <summary>Represents a nonexistent or invalid property or property value.</summary>
+			INVALID_CODE = -1
 		}
 
 		///<summary>
@@ -229,44 +483,82 @@ namespace Icu
 		/// <summary>
 		/// Decomposition Type constants.
 		/// </summary>
+		/// <remarks>
+		/// Note: UDecompositionType constants are parsed by preparseucd.py.
+		/// It matches lines like U_DT_&lt;Unicode Decomposition_Type value name&gt;
+		/// </remarks>
 		public enum UDecompositionType
 		{
+			/// <summary>[none]</summary>
 			NONE,
+			/// <summary>[can]</summary>
 			CANONICAL,
+			/// <summary>[com]</summary>
 			COMPAT,
+			/// <summary>[enc]</summary>
 			CIRCLE,
+			/// <summary>[fin]</summary>
 			FINAL,
+			/// <summary>[font]</summary>
 			FONT,
+			/// <summary>[fra]</summary>
 			FRACTION,
+			/// <summary>[init]</summary>
 			INITIAL,
+			/// <summary>[iso]</summary>
 			ISOLATED,
+			/// <summary>[med]</summary>
 			MEDIAL,
+			/// <summary>[nar]</summary>
 			NARROW,
+			/// <summary>[nb]</summary>
 			NOBREAK,
+			/// <summary>[sml]</summary>
 			SMALL,
+			/// <summary>[sqr]</summary>
 			SQUARE,
+			/// <summary>[sub]</summary>
 			SUB,
+			/// <summary>[sup]</summary>
 			SUPER,
+			/// <summary>[vert]</summary>
 			VERTICAL,
+			/// <summary>[wide]</summary>
 			WIDE,
+			/// <summary>18</summary>
 			COUNT
 		}
 
 		/// <summary>
 		/// Numeric Type constants
 		/// </summary>
+		/// <remarks>Note: UNumericType constants are parsed by preparseucd.py.
+		/// It matches lines like U_NT_&lt;Unicode Numeric_Type value name&gt;</remarks>
 		public enum UNumericType
 		{
+			/// <summary>[None]</summary>
 			NONE,
+			/// <summary>[de]</summary>
 			DECIMAL,
+			/// <summary>[di]</summary>
 			DIGIT,
+			/// <summary>[nu]</summary>
 			NUMERIC,
+			/// <summary></summary>
 			COUNT
 		}
 
+		/// <summary>
+		/// Special value that is returned by <see cref="GetNumericValue(int)"/>
+		/// when no numeric value is defined for a code point.
+		/// </summary>
 		public const double NO_NUMERIC_VALUE = (double)-123456789;
 
-		/// <summary></summary>
+		/// <summary>
+		/// Returns the decimal digit value of the code point in the specified radix.
+		/// </summary>
+		/// <param name="characterCode">The code point to be tested</param>
+		/// <param name="radix">The radix</param>
 		public static int Digit(int characterCode, byte radix)
 		{
 			return NativeMethods.u_digit(characterCode, radix);

--- a/source/icu.net/Character.cs
+++ b/source/icu.net/Character.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 SIL International
+﻿// Copyright (c) 2013 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System;
 using System.Globalization;
@@ -73,7 +73,7 @@ namespace Icu
 			/// <summary>Characters commonly used for hexadecimal numbers.</summary>
 			HEX_DIGIT = 13,
 			/// <summary>
-			/// Dashes used to mark connections between pieces of words,plus the
+			/// Dashes used to mark connections between pieces of words, plus the
 			/// Katakana middle dot.
 			/// </summary>
 			HYPHEN = 14,

--- a/source/icu.net/Collation/AlternateHandling.cs
+++ b/source/icu.net/Collation/AlternateHandling.cs
@@ -8,6 +8,9 @@ namespace Icu.Collation
 	/// </summary>
 	public enum AlternateHandling
 	{
+		/// <summary>
+		/// Default value that does nothing.
+		/// </summary>
 		Default = -1,
 		/// <summary>
 		/// causes codepoints with primary weights that are equal or below the variable top value

--- a/source/icu.net/Collation/CaseFirst.cs
+++ b/source/icu.net/Collation/CaseFirst.cs
@@ -8,6 +8,9 @@ namespace Icu.Collation
 	/// </summary>
 	public enum CaseFirst
 	{
+		/// <summary>
+		/// Default value that does nothing.
+		/// </summary>
 		Default = -1,
 		/// <summary>
 		/// orders upper and lower case letters in accordance to their tertiary weights

--- a/source/icu.net/Collation/CaseLevel.cs
+++ b/source/icu.net/Collation/CaseLevel.cs
@@ -13,6 +13,9 @@ namespace Icu.Collation
 	/// </summary>
 	public enum CaseLevel
 	{
+		/// <summary>
+		/// Default value that does nothing.
+		/// </summary>
 		Default = -1,
 		/// <summary>
 		/// case level is not generated

--- a/source/icu.net/Collation/Collator.cs
+++ b/source/icu.net/Collation/Collator.cs
@@ -9,46 +9,119 @@ using System.Runtime.InteropServices;
 
 namespace Icu.Collation
 {
+	/// <summary>
+	/// The Collator class performs locale-sensitive string comparison.
+	/// You use this class to build searching and sorting routines for natural
+	/// language text.
+	/// </summary>
 	public abstract class Collator : IComparer<string>, ICloneable, IDisposable
 	{
+		/// <summary>
+		/// Gets or sets the minimum strength that will be used in comparison
+		/// or transformation.
+		/// </summary>
 		public abstract CollationStrength Strength{ get; set; }
 
+		/// <summary>
+		/// Gets or sets the NormalizationMode
+		/// </summary>
 		public abstract NormalizationMode NormalizationMode{ get; set; }
 
+		/// <summary>
+		/// Gets or sets the FrenchCollation. Attribute for direction of
+		/// secondary weights - used in Canadian French.
+		/// </summary>
 		public abstract FrenchCollation FrenchCollation{ get; set; }
 
+		/// <summary>
+		/// Gets or sets the CaseLevel mode. Controls whether an extra case
+		/// level (positioned before the third level) is generated or not.
+		/// </summary>
+		/// <remarks></remarks>
 		public abstract CaseLevel CaseLevel{ get; set; }
 
+		/// <summary>
+		/// Gets or sets HiraganaQuaternary mode. When turned on, this attribute
+		/// positions Hiragana before all non-ignorables on quaternary level
+		/// This is a sneaky way to produce JIS sort order.
+		/// </summary>
+		[Obsolete("ICU 50 Implementation detail, cannot be set via API, was removed from implementation.")]
 		public abstract HiraganaQuaternary HiraganaQuaternary{ get; set; }
 
+		/// <summary>
+		/// Gets or sets NumericCollation mode. When turned on, this attribute
+		/// makes substrings of digits sort according to their numeric values.
+		/// </summary>
 		public abstract NumericCollation NumericCollation{ get; set; }
 
+		/// <summary>
+		/// Controls the ordering of upper and lower case letters.
+		/// </summary>
 		public abstract CaseFirst CaseFirst{ get; set; }
 
+		/// <summary>
+		/// Gets or sets attribute for handling variable elements.
+		/// </summary>
 		public abstract AlternateHandling AlternateHandling{ get; set; }
 
+		/// <summary>
+		/// Get a sort key for a string from the collator.
+		/// </summary>
+		/// <param name="source">The text</param>
 		public abstract SortKey GetSortKey(string source);
 
+		/// <summary>
+		/// Compare two strings.
+		/// </summary>
+		/// <param name="source">The source string</param>
+		/// <param name="target">The target string</param>
+		/// <returns>The result of comparing the strings; 0 if source == target;
+		/// 1 if source &gt; target; -1 source &lt; target</returns>
 		public abstract int Compare(string source, string target);
 
+		/// <summary>
+		/// Thread safe cloning operation.
+		/// </summary>
+		/// <returns>The result is a clone of a given collator.</returns>
 		public abstract object Clone();
 
+		/// <summary>
+		/// Specifies whether locale fallback is allowed.
+		/// For more information, see: http://userguide.icu-project.org/locale#TOC-Fallback
+		/// </summary>
 		public enum Fallback
 		{
+			/// <summary>Do not use Locale fallback</summary>
 			NoFallback,
+			/// <summary>Use locale fallback algorithm</summary>
 			FallbackAllowed
 		}
 
+		/// <summary>
+		/// Creates a collator with the current culture.  Does not allow
+		/// locale fallback.
+		/// </summary>
 		public static Collator Create()
 		{
 			return Create(CultureInfo.CurrentCulture);
 		}
 
+		/// <summary>
+		/// Creates a collator with the specified locale. Does not allow
+		/// locale fallback.
+		/// </summary>
+		/// <param name="localeId">Locale to use</param>
 		public static Collator Create(string localeId)
 		{
 			return Create(localeId, Fallback.NoFallback);
 		}
 
+		/// <summary>
+		/// Creates a collator with the given locale and whether to use locale
+		/// fallback when creating collator.
+		/// </summary>
+		/// <param name="localeId">The locale</param>
+		/// <param name="fallback">Whether to use locale fallback or not.</param>
 		public static Collator Create(string localeId, Fallback fallback)
 		{
 			if (localeId == null)
@@ -58,11 +131,20 @@ namespace Icu.Collation
 			return RuleBasedCollator.Create(localeId, fallback);
 		}
 
+		/// <summary>
+		/// Creates a collator with the given CultureInfo
+		/// </summary>
+		/// <param name="cultureInfo">Culture to use.</param>
 		public static Collator Create(CultureInfo cultureInfo)
 		{
 			return Create(cultureInfo, Fallback.NoFallback);
 		}
 
+		/// <summary>
+		/// Creates a collator with the given CultureInfo and fallback
+		/// </summary>
+		/// <param name="cultureInfo">Culture to use</param>
+		/// <param name="fallback">Whether to use locale fallback or not.</param>
 		public static Collator Create(CultureInfo cultureInfo, Fallback fallback)
 		{
 			if (cultureInfo == null)
@@ -72,6 +154,11 @@ namespace Icu.Collation
 			return Create(cultureInfo.IetfLanguageTag, fallback);
 		}
 
+		/// <summary>
+		/// Creates a SortKey with the given string and keyData
+		/// </summary>
+		/// <param name="originalString">String to use</param>
+		/// <param name="keyData">Data of the SortKey</param>
 		static public SortKey CreateSortKey(string originalString, byte[] keyData)
 		{
 			if (keyData == null)
@@ -81,6 +168,12 @@ namespace Icu.Collation
 			return CreateSortKey(originalString, keyData, keyData.Length);
 		}
 
+		/// <summary>
+		/// Creates a SortKey with the given string and keyData
+		/// </summary>
+		/// <param name="originalString">String to use</param>
+		/// <param name="keyData">Data of the SortKey</param>
+		/// <param name="keyDataLength">Length to use from keyData</param>
 		static public SortKey CreateSortKey(string originalString, byte[] keyData, int keyDataLength)
 		{
 			if (originalString == null)
@@ -293,9 +386,13 @@ namespace Icu.Collation
 			GC.SuppressFinalize(this);
 		}
 
+		/// <summary>
+		/// Releases the resources used by Collator.
+		/// </summary>
+		/// <param name="disposing">true to release managed and unmanaged
+		/// resources; false to release only unmanaged resources.</param>
 		protected virtual void Dispose(bool disposing) { }
 
 		#endregion
-
 	}
 }

--- a/source/icu.net/Collation/FrenchCollation.cs
+++ b/source/icu.net/Collation/FrenchCollation.cs
@@ -8,6 +8,9 @@ namespace Icu.Collation
 	/// </summary>
 	public enum FrenchCollation
 	{
+		/// <summary>
+		/// Default value, does nothing.
+		/// </summary>
 		Default = -1,
 		/// <summary>
 		/// treats secondary weights in the order they appear

--- a/source/icu.net/Collation/HiraganaQuaternary.cs
+++ b/source/icu.net/Collation/HiraganaQuaternary.cs
@@ -1,5 +1,7 @@
-// Copyright (c) 2013 SIL International
+﻿// Copyright (c) 2013 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+
+using System;
 
 namespace Icu.Collation
 {
@@ -8,6 +10,7 @@ namespace Icu.Collation
 	/// non-ignorables on quaternary level This is a sneaky way to produce JIS
 	/// sort order
 	/// </summary>
+	[Obsolete("ICU 50 Implementation detail, cannot be set via API, was removed from implementation.")]
 	public enum HiraganaQuaternary
 	{
 		/// <summary>
@@ -15,8 +18,8 @@ namespace Icu.Collation
 		/// </summary>
 		Default = -1,
 		/// <summary>
-		/// Turns off ability to position positions Hiragana before all
-		/// non-ignorables on quaternary level.
+		/// Turns off ability to position Hiragana before all non-ignorables on
+		/// quaternary level.
 		/// </summary>
 		Off = 16,
 		/// <summary>

--- a/source/icu.net/Collation/HiraganaQuaternary.cs
+++ b/source/icu.net/Collation/HiraganaQuaternary.cs
@@ -10,8 +10,18 @@ namespace Icu.Collation
 	/// </summary>
 	public enum HiraganaQuaternary
 	{
+		/// <summary>
+		/// Default value, does nothing.
+		/// </summary>
 		Default = -1,
+		/// <summary>
+		/// Turns off ability to position positions Hiragana before all
+		/// non-ignorables on quaternary level.
+		/// </summary>
 		Off = 16,
+		/// <summary>
+		/// positions Hiragana before all non-ignorables on quaternary level.
+		/// </summary>
 		On = 17
 	}
 }

--- a/source/icu.net/Collation/NormalizationMode.cs
+++ b/source/icu.net/Collation/NormalizationMode.cs
@@ -8,6 +8,9 @@ namespace Icu.Collation
 	/// </summary>
 	public enum NormalizationMode
 	{
+		/// <summary>
+		/// Default value, does nothing.
+		/// </summary>
 		Default = -1,
 		/// <summary>
 		/// no normalization check is performed. The correctness of the result is guaranteed only if the

--- a/source/icu.net/Collation/NumericCollation.cs
+++ b/source/icu.net/Collation/NumericCollation.cs
@@ -10,8 +10,17 @@ namespace Icu.Collation
 	/// </summary>
 	public enum NumericCollation
 	{
+		/// <summary>
+		/// Default value, does nothing.
+		/// </summary>
 		Default = -1,
+		/// <summary>
+		/// Turns off NumericCollation behaviour.
+		/// </summary>
 		Off = 16,
+		/// <summary>
+		/// Generates a collation for the numeric value of substrings of digits.
+		/// </summary>
 		On = 17
 	}
 }

--- a/source/icu.net/Collation/RuleBasedCollator.cs
+++ b/source/icu.net/Collation/RuleBasedCollator.cs
@@ -8,6 +8,10 @@ using System.Globalization;
 
 namespace Icu.Collation
 {
+	/// <summary>
+	/// The RuleBasedCollator class provides the implementation of
+	/// <see cref="Collator"/>, using data-driven tables.
+	/// </summary>
 	public sealed class RuleBasedCollator : Collator
 	{
 		internal sealed class SafeRuleBasedCollatorHandle : SafeHandle
@@ -154,6 +158,7 @@ namespace Icu.Collation
 		/// non-ignorables on quaternary level This is a sneaky way to produce JIS
 		/// sort order
 		/// </summary>
+		[Obsolete("ICU 50 Implementation detail, cannot be set via API, was removed from implementation.")]
 		public override HiraganaQuaternary HiraganaQuaternary
 		{
 			get { return (HiraganaQuaternary) GetAttribute(NativeMethods.CollationAttribute.HiraganaQuaternaryMode); }
@@ -252,6 +257,11 @@ namespace Icu.Collation
 			ExceptionFromErrorCode.ThrowIfError(e);
 		}
 
+		/// <summary>
+		/// Create a string enumerator of all locales for which a valid collator
+		/// may be opened.
+		/// </summary>
+		/// <returns></returns>
 		public static IList<string> GetAvailableCollationLocales()
 		{
 			List<string> locales = new List<string>();
@@ -347,11 +357,21 @@ namespace Icu.Collation
 			return copy;
 		}
 
+		/// <summary>
+		/// Opens a Collator for comparing strings using the given locale id.
+		/// Does not allow for locale fallback.
+		/// </summary>
+		/// <param name="localeId">Locale to use</param>
 		public static new Collator Create(string localeId)
 		{
 			return Create(localeId, Fallback.NoFallback);
 		}
 
+		/// <summary>
+		/// Opens a Collator for comparing strings using the given locale id.
+		/// </summary>
+		/// <param name="localeId">Locale to use</param>
+		/// <param name="fallback">Whether to allow locale fallback or not.</param>
 		public static new Collator Create(string localeId, Fallback fallback)
 		{
 			// Culture identifiers in .NET are created using '-', while ICU
@@ -491,6 +511,9 @@ namespace Icu.Collation
 			}
 		}
 
+		/// <summary>
+		/// Disposes of all unmanaged resources used by RulesBasedCollator.
+		/// </summary>
 		~RuleBasedCollator()
 		{
 			Dispose(false);

--- a/source/icu.net/Collation/UColRuleOption.cs
+++ b/source/icu.net/Collation/UColRuleOption.cs
@@ -1,12 +1,24 @@
 // Copyright (c) 2013 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
-using System;
 
 namespace Icu.Collation
 {
+	/// <summary>
+	/// Options for retrieving the rule string.
+	/// </summary>
 	public enum UColRuleOption
 	{
+		/// <summary>
+		/// Retrieves the tailoring rules only.
+		/// </summary>
 		UCOL_TAILORING_ONLY = 0,
+		/// <summary>
+		/// Retrieves the "UCA rules" concatenated with the tailoring rules.
+		/// The "UCA rules" are an approximation of the root collator's sort
+		/// order. They are almost never used or useful at runtime and can be
+		/// removed from the data. 
+		/// See http://userguide.icu-project.org/collation/customization#TOC-Building-on-Existing-Locales
+		/// </summary>
 		UCOL_FULL_RULES
 	}
 }

--- a/source/icu.net/ErrorCode.cs
+++ b/source/icu.net/ErrorCode.cs
@@ -7,193 +7,340 @@ using System.IO;
 
 namespace Icu
 {
+	/// <summary>
+	/// Error code to replace exception handling, so that the code is compatible
+	/// with all C++ compilers, and to use the same mechanism for C and C++.
+	/// Error codes should be tested using <see cref="ErrorCodeExtensions.IsFailure(ErrorCode)"/>
+	/// and <see cref="ErrorCodeExtensions.IsSuccess(ErrorCode)"/>
+	/// </summary>
 	public enum ErrorCode
 	{
-		USING_FALLBACK_WARNING = -128,   /** A resource bundle lookup returned a fallback result (not an error) */
+		/// <summary>A resource bundle lookup returned a fallback result (not an error)</summary>
+		USING_FALLBACK_WARNING = -128,
+		/// <summary>Start of information results (semantically successful)</summary>
+		ERROR_WARNING_START = -128,
+		/// <summary>A resource bundle lookup returned a result from the root locale (not an error)</summary>
+		USING_DEFAULT_WARNING = -127,
+		/// <summary>A SafeClone operation required allocating memory (informational only)</summary>
+		SAFECLONE_ALLOCATED_WARNING = -126,
+		/// <summary>ICU has to use compatibility layer to construct the service. Expect performance/memory usage degradation. Consider upgrading</summary>
+		STATE_OLD_WARNING = -125,
+		/// <summary>An output string could not be NUL-terminated because output length==destCapacity.</summary>
+		STRING_NOT_TERMINATED_WARNING = -124,
+		/// <summary>Number of levels requested in getBound is higher than the number of levels in the sort key</summary>
+		SORT_KEY_TOO_SHORT_WARNING = -123,
+		/// <summary>This converter alias can go to different converter implementations</summary>
+		AMBIGUOUS_ALIAS_WARNING = -122,
+		/// <summary>ucol_open encountered a mismatch between UCA version and collator image version, so the collator was constructed from rules. No impact to further function</summary>
+		DIFFERENT_UCA_VERSION = -121,
+		/// <summary>This must always be the last warning value to indicate the limit for UErrorCode warnings (last warning code +1)</summary>
+		ERROR_WARNING_LIMIT,
+		/// <summary>No error, no warning.</summary>
 
-		ERROR_WARNING_START = -128,   /** Start of information results (semantically successful) */
-
-		USING_DEFAULT_WARNING = -127,   /** A resource bundle lookup returned a result from the root locale (not an error) */
-
-		SAFECLONE_ALLOCATED_WARNING = -126, /** A SafeClone operation required allocating memory (informational only) */
-
-		STATE_OLD_WARNING = -125,   /** ICU has to use compatibility layer to construct the service. Expect performance/memory usage degradation. Consider upgrading */
-
-		STRING_NOT_TERMINATED_WARNING = -124,/** An output string could not be NUL-terminated because output length==destCapacity. */
-
-		SORT_KEY_TOO_SHORT_WARNING = -123, /** Number of levels requested in getBound is higher than the number of levels in the sort key */
-
-		AMBIGUOUS_ALIAS_WARNING = -122,   /** This converter alias can go to different converter implementations */
-
-		DIFFERENT_UCA_VERSION = -121,     /** ucol_open encountered a mismatch between UCA version and collator image version, so the collator was constructed from rules. No impact to further function */
-
-		ERROR_WARNING_LIMIT,              /** This must always be the last warning value to indicate the limit for UErrorCode warnings (last warning code +1) */
-
-
-		ZERO_ERROR = 0,     /** No error, no warning. */
+		ZERO_ERROR = 0,
+		/// <summary>No error, no warning.</summary>
 		NoErrors = ZERO_ERROR,
-		ILLEGAL_ARGUMENT_ERROR = 1,     /** Start of codes indicating failure */
-		MISSING_RESOURCE_ERROR = 2,     /** The requested resource cannot be found */
-		INVALID_FORMAT_ERROR = 3,     /** Data format is not what is expected */
-		FILE_ACCESS_ERROR = 4,     /** The requested file cannot be found */
-		INTERNAL_PROGRAM_ERROR = 5,     /** Indicates a bug in the library code */
-		MESSAGE_PARSE_ERROR = 6,     /** Unable to parse a message (message format) */
-		MEMORY_ALLOCATION_ERROR = 7,     /** Memory allocation error */
-		INDEX_OUTOFBOUNDS_ERROR = 8,     /** Trying to access the index that is out of bounds */
-		PARSE_ERROR = 9,     /** Equivalent to Java ParseException */
-		INVALID_CHAR_FOUND = 10,     /** Character conversion: Unmappable input sequence. In other APIs: Invalid character. */
-		TRUNCATED_CHAR_FOUND = 11,     /** Character conversion: Incomplete input sequence. */
-		ILLEGAL_CHAR_FOUND = 12,     /** Character conversion: Illegal input sequence/combination of input units. */
-		INVALID_TABLE_FORMAT = 13,     /** Conversion table file found, but corrupted */
-		INVALID_TABLE_FILE = 14,     /** Conversion table file not found */
-		BUFFER_OVERFLOW_ERROR = 15,     /** A result would not fit in the supplied buffer */
-		UNSUPPORTED_ERROR = 16,     /** Requested operation not supported in current context */
-		RESOURCE_TYPE_MISMATCH = 17,     /** an operation is requested over a resource that does not support it */
-		ILLEGAL_ESCAPE_SEQUENCE = 18,     /** ISO-2022 illlegal escape sequence */
-		UNSUPPORTED_ESCAPE_SEQUENCE = 19, /** ISO-2022 unsupported escape sequence */
-		NO_SPACE_AVAILABLE = 20,     /** No space available for in-buffer expansion for Arabic shaping */
-		CE_NOT_FOUND_ERROR = 21,     /** Currently used only while setting variable top, but can be used generally */
-		PRIMARY_TOO_LONG_ERROR = 22,     /** User tried to set variable top to a primary that is longer than two bytes */
-		STATE_TOO_OLD_ERROR = 23,     /** ICU cannot construct a service from this state, as it is no longer supported */
-		TOO_MANY_ALIASES_ERROR = 24,     /** There are too many aliases in the path to the requested resource.
-										   It is very possible that a circular alias definition has occured */
-		ENUM_OUT_OF_SYNC_ERROR = 25,     /** UEnumeration out of sync with underlying collection */
-		INVARIANT_CONVERSION_ERROR = 26,  /** Unable to convert a UChar* string to char* with the invariant converter. */
-		INVALID_STATE_ERROR = 27,     /** Requested operation can not be completed with ICU in its current state */
-		COLLATOR_VERSION_MISMATCH = 28,   /** Collator version is not compatible with the base version */
-		USELESS_COLLATOR_ERROR = 29,     /** Collator is options only and no base is specified */
-		NO_WRITE_PERMISSION = 30,     /** Attempt to modify read-only or constant data. */
-
-		STANDARD_ERROR_LIMIT,             /** This must always be the last value to indicate the limit for standard errors */
+		/// <summary>Start of codes indicating failure</summary>
+		ILLEGAL_ARGUMENT_ERROR = 1,
+		/// <summary>The requested resource cannot be found</summary>
+		MISSING_RESOURCE_ERROR = 2,
+		/// <summary>Data format is not what is expected</summary>
+		INVALID_FORMAT_ERROR = 3,
+		/// <summary>The requested file cannot be found</summary>
+		FILE_ACCESS_ERROR = 4,
+		/// <summary>Indicates a bug in the library code</summary>
+		INTERNAL_PROGRAM_ERROR = 5,
+		/// <summary>Unable to parse a message (message format)</summary>
+		MESSAGE_PARSE_ERROR = 6,
+		/// <summary>Memory allocation error</summary>
+		MEMORY_ALLOCATION_ERROR = 7,
+		/// <summary>Trying to access the index that is out of bounds</summary>
+		INDEX_OUTOFBOUNDS_ERROR = 8,
+		/// <summary>Equivalent to Java ParseException</summary>
+		PARSE_ERROR = 9,
+		/// <summary>Character conversion: Unmappable input sequence. In other APIs: Invalid character.</summary>
+		INVALID_CHAR_FOUND = 10,
+		/// <summary>Character conversion: Incomplete input sequence.</summary>
+		TRUNCATED_CHAR_FOUND = 11,
+		/// <summary>Character conversion: Illegal input sequence/combination of input units.</summary>
+		ILLEGAL_CHAR_FOUND = 12,
+		/// <summary>Conversion table file found, but corrupted</summary>
+		INVALID_TABLE_FORMAT = 13,
+		/// <summary>Conversion table file not found</summary>
+		INVALID_TABLE_FILE = 14,
+		/// <summary>A result would not fit in the supplied buffer</summary>
+		BUFFER_OVERFLOW_ERROR = 15,
+		/// <summary>Requested operation not supported in current context</summary>
+		UNSUPPORTED_ERROR = 16,
+		/// <summary>an operation is requested over a resource that does not support it</summary>
+		RESOURCE_TYPE_MISMATCH = 17,
+		/// <summary>ISO-2022 illlegal escape sequence</summary>
+		ILLEGAL_ESCAPE_SEQUENCE = 18,
+		/// <summary>ISO-2022 unsupported escape sequence</summary>
+		UNSUPPORTED_ESCAPE_SEQUENCE = 19,
+		/// <summary>No space available for in-buffer expansion for Arabic shaping</summary>
+		NO_SPACE_AVAILABLE = 20,
+		/// <summary>Currently used only while setting variable top, but can be used generally</summary>
+		CE_NOT_FOUND_ERROR = 21,
+		/// <summary>User tried to set variable top to a primary that is longer than two bytes</summary>
+		PRIMARY_TOO_LONG_ERROR = 22,
+		/// <summary>ICU cannot construct a service from this state, as it is no longer supported</summary>
+		STATE_TOO_OLD_ERROR = 23,
+		/// <summary>
+		/// There are too many aliases in the path to the requested resource.
+		/// It is very possible that a circular alias definition has occured
+		/// </summary>
+		TOO_MANY_ALIASES_ERROR = 24,
+		/// <summary>UEnumeration out of sync with underlying collection</summary>
+		ENUM_OUT_OF_SYNC_ERROR = 25,
+		/// <summary>Unable to convert a UChar* string to char* with the invariant converter.</summary>
+		INVARIANT_CONVERSION_ERROR = 26,
+		/// <summary>Requested operation can not be completed with ICU in its current state</summary>
+		INVALID_STATE_ERROR = 27,
+		/// <summary>Collator version is not compatible with the base version</summary>
+		COLLATOR_VERSION_MISMATCH = 28,
+		/// <summary>Collator is options only and no base is specified</summary>
+		USELESS_COLLATOR_ERROR = 29,
+		/// <summary>Attempt to modify read-only or constant data.</summary>
+		NO_WRITE_PERMISSION = 30,
+		/// <summary>This must always be the last value to indicate the limit for standard errors</summary>
+		STANDARD_ERROR_LIMIT,
 		/*
 		 * the error code range 0x10000 0x10100 are reserved for Transliterator
 		 */
-		BAD_VARIABLE_DEFINITION = 0x10000,/** Missing '$' or duplicate variable name */
-		PARSE_ERROR_START = 0x10000,    /** Start of Transliterator errors */
-		MALFORMED_RULE,                 /** Elements of a rule are misplaced */
-		MALFORMED_SET,                  /** A UnicodeSet pattern is invalid*/
-		MALFORMED_SYMBOL_REFERENCE,     /** UNUSED as of ICU 2.4 */
-		MALFORMED_UNICODE_ESCAPE,       /** A Unicode escape pattern is invalid*/
-		MALFORMED_VARIABLE_DEFINITION,  /** A variable definition is invalid */
-		MALFORMED_VARIABLE_REFERENCE,   /** A variable reference is invalid */
-		MISMATCHED_SEGMENT_DELIMITERS,  /** UNUSED as of ICU 2.4 */
-		MISPLACED_ANCHOR_START,         /** A start anchor appears at an illegal position */
-		MISPLACED_CURSOR_OFFSET,        /** A cursor offset occurs at an illegal position */
-		MISPLACED_QUANTIFIER,           /** A quantifier appears after a segment close delimiter */
-		MISSING_OPERATOR,               /** A rule contains no operator */
-		MISSING_SEGMENT_CLOSE,          /** UNUSED as of ICU 2.4 */
-		MULTIPLE_ANTE_CONTEXTS,         /** More than one ante context */
-		MULTIPLE_CURSORS,               /** More than one cursor */
-		MULTIPLE_POST_CONTEXTS,         /** More than one post context */
-		TRAILING_BACKSLASH,             /** A dangling backslash */
-		UNDEFINED_SEGMENT_REFERENCE,    /** A segment reference does not correspond to a defined segment */
-		UNDEFINED_VARIABLE,             /** A variable reference does not correspond to a defined variable */
-		UNQUOTED_SPECIAL,               /** A special character was not quoted or escaped */
-		UNTERMINATED_QUOTE,             /** A closing single quote is missing */
-		RULE_MASK_ERROR,                /** A rule is hidden by an earlier more general rule */
-		MISPLACED_COMPOUND_FILTER,      /** A compound filter is in an invalid location */
-		MULTIPLE_COMPOUND_FILTERS,      /** More than one compound filter */
-		INVALID_RBT_SYNTAX,             /** A "::id" rule was passed to the RuleBasedTransliterator parser */
-		INVALID_PROPERTY_PATTERN,       /** UNUSED as of ICU 2.4 */
-		MALFORMED_PRAGMA,               /** A 'use' pragma is invlalid */
-		UNCLOSED_SEGMENT,               /** A closing ')' is missing */
-		ILLEGAL_CHAR_IN_SEGMENT,        /** UNUSED as of ICU 2.4 */
-		VARIABLE_RANGE_EXHAUSTED,       /** Too many stand-ins generated for the given variable range */
-		VARIABLE_RANGE_OVERLAP,         /** The variable range overlaps characters used in rules */
-		ILLEGAL_CHARACTER,              /** A special character is outside its allowed context */
-		INTERNAL_TRANSLITERATOR_ERROR,  /** Internal transliterator system error */
-		INVALID_ID,                     /** A "::id" rule specifies an unknown transliterator */
-		INVALID_FUNCTION,               /** A "&amp;fn()" rule specifies an unknown transliterator */
-		PARSE_ERROR_LIMIT,              /** The limit for Transliterator errors */
+		/// <summary>Missing '$' or duplicate variable name</summary>
+		BAD_VARIABLE_DEFINITION = 0x10000,
+		/// <summary>Start of Transliterator errors</summary>
+		PARSE_ERROR_START = 0x10000,
+		/// <summary>Elements of a rule are misplaced</summary>
+		MALFORMED_RULE,
+		/// <summary>A UnicodeSet pattern is invalid</summary>
+		MALFORMED_SET,
+		/// <summary>UNUSED as of ICU 2.4</summary>
+		MALFORMED_SYMBOL_REFERENCE,
+		/// <summary>A Unicode escape pattern is invalid</summary>
+		MALFORMED_UNICODE_ESCAPE,
+		/// <summary>A variable definition is invalid</summary>
+		MALFORMED_VARIABLE_DEFINITION,
+		/// <summary>A variable reference is invalid</summary>
+		MALFORMED_VARIABLE_REFERENCE,
+		/// <summary>UNUSED as of ICU 2.4</summary>
+		MISMATCHED_SEGMENT_DELIMITERS,
+		/// <summary>A start anchor appears at an illegal position</summary>
+		MISPLACED_ANCHOR_START,
+		/// <summary>A cursor offset occurs at an illegal position</summary>
+		MISPLACED_CURSOR_OFFSET,
+		/// <summary>A quantifier appears after a segment close delimiter</summary>
+		MISPLACED_QUANTIFIER,
+		/// <summary>A rule contains no operator</summary>
+		MISSING_OPERATOR,
+		/// <summary>UNUSED as of ICU 2.4</summary>
+		MISSING_SEGMENT_CLOSE,
+		/// <summary>More than one ante context</summary>
+		MULTIPLE_ANTE_CONTEXTS,
+		/// <summary>More than one cursor</summary>
+		MULTIPLE_CURSORS,
+		/// <summary>More than one post context</summary>
+		MULTIPLE_POST_CONTEXTS,
+		/// <summary>A dangling backslash</summary>
+		TRAILING_BACKSLASH,
+		/// <summary>A segment reference does not correspond to a defined segment</summary>
+		UNDEFINED_SEGMENT_REFERENCE,
+		/// <summary>A variable reference does not correspond to a defined variable</summary>
+		UNDEFINED_VARIABLE,
+		/// <summary>A special character was not quoted or escaped</summary>
+		UNQUOTED_SPECIAL,
+		/// <summary>A closing single quote is missing</summary>
+		UNTERMINATED_QUOTE,
+		/// <summary>A rule is hidden by an earlier more general rule</summary>
+		RULE_MASK_ERROR,
+		/// <summary>A compound filter is in an invalid location</summary>
+		MISPLACED_COMPOUND_FILTER,
+		/// <summary>More than one compound filter</summary>
+		MULTIPLE_COMPOUND_FILTERS,
+		/// <summary>A "::id" rule was passed to the RuleBasedTransliterator parser</summary>
+		INVALID_RBT_SYNTAX,
+		/// <summary>UNUSED as of ICU 2.4</summary>
+		INVALID_PROPERTY_PATTERN,
+		/// <summary>A 'use' pragma is invlalid</summary>
+		MALFORMED_PRAGMA,
+		/// <summary>A closing ')' is missing</summary>
+		UNCLOSED_SEGMENT,
+		/// <summary>UNUSED as of ICU 2.4</summary>
+		ILLEGAL_CHAR_IN_SEGMENT,
+		/// <summary>Too many stand-ins generated for the given variable range</summary>
+		VARIABLE_RANGE_EXHAUSTED,
+		/// <summary>The variable range overlaps characters used in rules</summary>
+		VARIABLE_RANGE_OVERLAP,
+		/// <summary>A special character is outside its allowed context</summary>
+		ILLEGAL_CHARACTER,
+		/// <summary>Internal transliterator system error</summary>
+		INTERNAL_TRANSLITERATOR_ERROR,
+		/// <summary>A "::id" rule specifies an unknown transliterator</summary>
+		INVALID_ID,
+		/// <summary>A "&amp;fn()" rule specifies an unknown transliterator</summary>
+		INVALID_FUNCTION,
+		/// <summary>The limit for Transliterator errors</summary>
+		PARSE_ERROR_LIMIT,
 		 /*
 		 * the error code range 0x10100 0x10200 are reserved for formatting API parsing error
 		 */
-		UNEXPECTED_TOKEN = 0x10100,       /** Syntax error in format pattern */
-		FMT_PARSE_ERROR_START = 0x10100,  /** Start of format library errors */
-		MULTIPLE_DECIMAL_SEPARATORS,    /** More than one decimal separator in number pattern */
-		MULTIPLE_EXPONENTIAL_SYMBOLS,   /** More than one exponent symbol in number pattern */
-		MALFORMED_EXPONENTIAL_PATTERN,  /** Grouping symbol in exponent pattern */
-		MULTIPLE_PERCENT_SYMBOLS,       /** More than one percent symbol in number pattern */
-		MULTIPLE_PERMILL_SYMBOLS,       /** More than one permill symbol in number pattern */
-		MULTIPLE_PAD_SPECIFIERS,        /** More than one pad symbol in number pattern */
-		PATTERN_SYNTAX_ERROR,           /** Syntax error in format pattern */
-		ILLEGAL_PAD_POSITION,           /** Pad symbol misplaced in number pattern */
-		UNMATCHED_BRACES,               /** Braces do not match in message pattern */
-		UNSUPPORTED_PROPERTY,           /** UNUSED as of ICU 2.4 */
-		UNSUPPORTED_ATTRIBUTE,          /** UNUSED as of ICU 2.4 */
-		ARGUMENT_TYPE_MISMATCH,         /** Argument name and argument index mismatch in MessageFormat functions. */
-		DUPLICATE_KEYWORD,              /** Duplicate keyword in PluralFormat. */
-		UNDEFINED_KEYWORD,              /** Undefined Plural keyword. */
-		DEFAULT_KEYWORD_MISSING,        /** Missing DEFAULT rule in plural rules. */
-		FMT_PARSE_ERROR_LIMIT,          /** The limit for format library errors */
+		/// <summary>Syntax error in format pattern</summary>
+		UNEXPECTED_TOKEN = 0x10100,
+		/// <summary>Start of format library errors</summary>
+		FMT_PARSE_ERROR_START = 0x10100,
+		/// <summary>More than one decimal separator in number pattern</summary>
+		MULTIPLE_DECIMAL_SEPARATORS,
+		/// <summary>More than one exponent symbol in number pattern</summary>
+		MULTIPLE_EXPONENTIAL_SYMBOLS,
+		/// <summary>Grouping symbol in exponent pattern</summary>
+		MALFORMED_EXPONENTIAL_PATTERN,
+		/// <summary>More than one percent symbol in number pattern</summary>
+		MULTIPLE_PERCENT_SYMBOLS,
+		/// <summary>More than one permill symbol in number pattern</summary>
+		MULTIPLE_PERMILL_SYMBOLS,
+		/// <summary>More than one pad symbol in number pattern</summary>
+		MULTIPLE_PAD_SPECIFIERS,
+		/// <summary>Syntax error in format pattern</summary>
+		PATTERN_SYNTAX_ERROR,
+		/// <summary>Pad symbol misplaced in number pattern</summary>
+		ILLEGAL_PAD_POSITION,
+		/// <summary>Braces do not match in message pattern</summary>
+		UNMATCHED_BRACES,
+		/// <summary>UNUSED as of ICU 2.4</summary>
+		UNSUPPORTED_PROPERTY,
+		/// <summary>UNUSED as of ICU 2.4</summary>
+		UNSUPPORTED_ATTRIBUTE,
+		/// <summary>Argument name and argument index mismatch in MessageFormat functions.</summary>
+		ARGUMENT_TYPE_MISMATCH,
+		/// <summary>Duplicate keyword in PluralFormat.</summary>
+		DUPLICATE_KEYWORD,
+		/// <summary>Undefined Plural keyword.</summary>
+		UNDEFINED_KEYWORD,
+		/// <summary>Missing DEFAULT rule in plural rules.</summary>
+		DEFAULT_KEYWORD_MISSING,
+		/// <summary>The limit for format library errors</summary>
+		FMT_PARSE_ERROR_LIMIT,
 				/*
 		 * the error code range 0x10200 0x102ff are reserved for Break Iterator related error
 		 */
-		BRK_INTERNAL_ERROR = 0x10200,          /** An internal error (bug) was detected.             */
-		BRK_ERROR_START = 0x10200,             /** Start of codes indicating Break Iterator failures */
-		BRK_HEX_DIGITS_EXPECTED,             /** Hex digits expected as part of a escaped char in a rule. */
-		BRK_SEMICOLON_EXPECTED,              /** Missing ';' at the end of a RBBI rule.            */
-		BRK_RULE_SYNTAX,                     /** Syntax error in RBBI rule.                        */
-		BRK_UNCLOSED_SET,                    /** UnicodeSet witing an RBBI rule missing a closing ']'.  */
-		BRK_ASSIGN_ERROR,                    /** Syntax error in RBBI rule assignment statement.   */
-		BRK_VARIABLE_REDFINITION,            /** RBBI rule $Variable redefined.                    */
-		BRK_MISMATCHED_PAREN,                /** Mis-matched parentheses in an RBBI rule.          */
-		BRK_NEW_LINE_IN_QUOTED_STRING,       /** Missing closing quote in an RBBI rule.            */
-		BRK_UNDEFINED_VARIABLE,              /** Use of an undefined $Variable in an RBBI rule.    */
-		BRK_INIT_ERROR,                      /** Initialization failure.  Probable missing ICU Data. */
-		BRK_RULE_EMPTY_SET,                  /** Rule contains an empty Unicode Set.               */
-		BRK_UNRECOGNIZED_OPTION,             /** !!option in RBBI rules not recognized.            */
-		BRK_MALFORMED_RULE_TAG,              /** The {nnn} tag on a rule is mal formed             */
-		BRK_ERROR_LIMIT,                     /** This must always be the last value to indicate the limit for Break Iterator failures */
+		/// <summary>An internal error (bug) was detected.</summary>
+		BRK_INTERNAL_ERROR = 0x10200,
+		/// <summary>Start of codes indicating Break Iterator failures</summary>
+		BRK_ERROR_START = 0x10200,
+		/// <summary>Hex digits expected as part of a escaped char in a rule.</summary>
+		BRK_HEX_DIGITS_EXPECTED,
+		/// <summary>Missing ';' at the end of a RBBI rule.</summary>
+		BRK_SEMICOLON_EXPECTED,
+		/// <summary>Syntax error in RBBI rule.</summary>
+		BRK_RULE_SYNTAX,
+		/// <summary>UnicodeSet witing an RBBI rule missing a closing ']'.</summary>
+		BRK_UNCLOSED_SET,
+		/// <summary>Syntax error in RBBI rule assignment statement.</summary>
+		BRK_ASSIGN_ERROR,
+		/// <summary>RBBI rule $Variable redefined.</summary>
+		BRK_VARIABLE_REDFINITION,
+		/// <summary>Mis-matched parentheses in an RBBI rule.</summary>
+		BRK_MISMATCHED_PAREN,
+		/// <summary>Missing closing quote in an RBBI rule.</summary>
+		BRK_NEW_LINE_IN_QUOTED_STRING,
+		/// <summary>Use of an undefined $Variable in an RBBI rule.</summary>
+		BRK_UNDEFINED_VARIABLE,
+		/// <summary>Initialization failure.  Probable missing ICU Data.</summary>
+		BRK_INIT_ERROR,
+		/// <summary>Rule contains an empty Unicode Set.</summary>
+		BRK_RULE_EMPTY_SET,
+		/// <summary>!!option in RBBI rules not recognized.</summary>
+		BRK_UNRECOGNIZED_OPTION,
+		/// <summary>The {nnn} tag on a rule is mal formed</summary>
+		BRK_MALFORMED_RULE_TAG,
+		/// <summary>This must always be the last value to indicate the limit for Break Iterator failures</summary>
+		BRK_ERROR_LIMIT,
 				/*
 		 * The error codes in the range 0x10300-0x103ff are reserved for regular expression related errrs
 		 */
-		REGEX_INTERNAL_ERROR = 0x10300,       /** An internal error (bug) was detected.              */
-		REGEX_ERROR_START = 0x10300,          /** Start of codes indicating Regexp failures          */
-		REGEX_RULE_SYNTAX,                  /** Syntax error in regexp pattern.                    */
-		REGEX_INVALID_STATE,                /** RegexMatcher in invalid state for requested operation */
-		REGEX_BAD_ESCAPE_SEQUENCE,          /** Unrecognized backslash escape sequence in pattern  */
-		REGEX_PROPERTY_SYNTAX,              /** Incorrect Unicode property                         */
-		REGEX_UNIMPLEMENTED,                /** Use of regexp feature that is not yet implemented. */
-		REGEX_MISMATCHED_PAREN,             /** Incorrectly nested parentheses in regexp pattern.  */
-		REGEX_NUMBER_TOO_BIG,               /** Decimal number is too large.                       */
-		REGEX_BAD_INTERVAL,                 /** Error in {min,max} interval                        */
-		REGEX_MAX_LT_MIN,                   /** In {min,max}, max is less than min.                */
-		REGEX_INVALID_BACK_REF,             /** Back-reference to a non-existent capture group.    */
-		REGEX_INVALID_FLAG,                 /** Invalid value for match mode flags.                */
-		REGEX_LOOK_BEHIND_LIMIT,            /** Look-Behind pattern matches must have a bounded maximum length.    */
-		REGEX_SET_CONTAINS_STRING,          /** Regexps cannot have UnicodeSets containing strings.*/
-		REGEX_OCTAL_TOO_BIG,                /** Octal character constants must be &lt;= 0377. */
-		REGEX_MISSING_CLOSE_BRACKET,        /** Missing closing bracket on a bracket expression. */
-		REGEX_INVALID_RANGE,                /** In a character range [x-y], x is greater than y. */
-		REGEX_STACK_OVERFLOW,               /** Regular expression backtrack stack overflow. */
-		REGEX_TIME_OUT,                     /** Maximum allowed match time exceeded. */
-		REGEX_STOPPED_BY_CALLER,            /** Matching operation aborted by user callback fn. */
-		REGEX_ERROR_LIMIT,                  /** This must always be the last value to indicate the limit for regexp errors */
+		/// <summary>An internal error (bug) was detected.</summary>
+		REGEX_INTERNAL_ERROR = 0x10300,
+		/// <summary>Start of codes indicating Regexp failures</summary>
+		REGEX_ERROR_START = 0x10300,
+		/// <summary>Syntax error in regexp pattern.</summary>
+		REGEX_RULE_SYNTAX,
+		/// <summary>RegexMatcher in invalid state for requested operation</summary>
+		REGEX_INVALID_STATE,
+		/// <summary>Unrecognized backslash escape sequence in pattern</summary>
+		REGEX_BAD_ESCAPE_SEQUENCE,
+		/// <summary>Incorrect Unicode property</summary>
+		REGEX_PROPERTY_SYNTAX,
+		/// <summary>Use of regexp feature that is not yet implemented.</summary>
+		REGEX_UNIMPLEMENTED,
+		/// <summary>Incorrectly nested parentheses in regexp pattern.</summary>
+		REGEX_MISMATCHED_PAREN,
+		/// <summary>Decimal number is too large.</summary>
+		REGEX_NUMBER_TOO_BIG,
+		/// <summary>Error in {min,max} interval</summary>
+		REGEX_BAD_INTERVAL,
+		/// <summary>In {min,max}, max is less than min.</summary>
+		REGEX_MAX_LT_MIN,
+		/// <summary>Back-reference to a non-existent capture group.</summary>
+		REGEX_INVALID_BACK_REF,
+		/// <summary>Invalid value for match mode flags.</summary>
+		REGEX_INVALID_FLAG,
+		/// <summary>Look-Behind pattern matches must have a bounded maximum length.</summary>
+		REGEX_LOOK_BEHIND_LIMIT,
+		/// <summary>Regexps cannot have UnicodeSets containing strings.</summary>
+		REGEX_SET_CONTAINS_STRING,
+		/// <summary>Octal character constants must be &lt;= 0377.</summary>
+		REGEX_OCTAL_TOO_BIG,
+		/// <summary>Missing closing bracket on a bracket expression.</summary>
+		REGEX_MISSING_CLOSE_BRACKET,
+		/// <summary>In a character range [x-y], x is greater than y.</summary>
+		REGEX_INVALID_RANGE,
+		/// <summary>Regular expression backtrack stack overflow.</summary>
+		REGEX_STACK_OVERFLOW,
+		/// <summary>Maximum allowed match time exceeded.</summary>
+		REGEX_TIME_OUT,
+		/// <summary>Matching operation aborted by user callback fn.</summary>
+		REGEX_STOPPED_BY_CALLER,
+		/// <summary>This must always be the last value to indicate the limit for regexp errors</summary>
+		REGEX_ERROR_LIMIT,
 
 		/*
 		 * The error code in the range 0x10400-0x104ff are reserved for IDNA related error codes
 		 */
+		/// <summary></summary>
 		IDNA_PROHIBITED_ERROR = 0x10400,
+		/// <summary>Start of codes indicating IDNA failures</summary>
 		IDNA_ERROR_START = 0x10400,
+		/// <summary></summary>
 		IDNA_UNASSIGNED_ERROR,
+		/// <summary></summary>
 		IDNA_CHECK_BIDI_ERROR,
+		/// <summary></summary>
 		IDNA_STD3_ASCII_RULES_ERROR,
+		/// <summary></summary>
 		IDNA_ACE_PREFIX_ERROR,
+		/// <summary></summary>
 		IDNA_VERIFICATION_ERROR,
+		/// <summary></summary>
 		IDNA_LABEL_TOO_LONG_ERROR,
+		/// <summary></summary>
 		IDNA_ZERO_LENGTH_LABEL_ERROR,
+		/// <summary></summary>
 		IDNA_DOMAIN_NAME_TOO_LONG_ERROR,
+		/// <summary>This must always be the last value to indicate the limit for IDNA errors</summary>
 		IDNA_ERROR_LIMIT,
 		/*
 		 * Aliases for StringPrep
 		 */
+		/// <summary></summary>
 		STRINGPREP_PROHIBITED_ERROR = IDNA_PROHIBITED_ERROR,
+		/// <summary></summary>
 		STRINGPREP_UNASSIGNED_ERROR = IDNA_UNASSIGNED_ERROR,
+		/// <summary></summary>
 		STRINGPREP_CHECK_BIDI_ERROR = IDNA_CHECK_BIDI_ERROR,
 
-
-		ERROR_LIMIT = IDNA_ERROR_LIMIT      /** This must always be the last value to indicate the limit for UErrorCode (last error code +1) */
+		/// <summary>This must always be the last value to indicate the limit for UErrorCode (last error code +1)</summary>
+		ERROR_LIMIT = IDNA_ERROR_LIMIT
 	}
 
 	internal static class ErrorCodeExtensions

--- a/source/icu.net/IcuWrapper.cs
+++ b/source/icu.net/IcuWrapper.cs
@@ -5,6 +5,10 @@ using System.Runtime.InteropServices;
 
 namespace Icu
 {
+	/// <summary>
+	/// Helps fetch information about ICU library such as ICU version, data
+	/// folder, etc.
+	/// </summary>
 	public static class Wrapper
 	{
 		#region Public Properties

--- a/source/icu.net/Locale.cs
+++ b/source/icu.net/Locale.cs
@@ -8,6 +8,9 @@ using System.Text;
 
 namespace Icu
 {
+	/// <summary>
+	/// A Locale object represents a specific geographical, political, or cultural region.
+	/// </summary>
 	public class Locale: ICloneable
 	{
 		/// <summary>
@@ -38,11 +41,24 @@ namespace Icu
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Locale"/> class.
+		/// </summary>
+		/// <param name="language">Lowercase two-letter or three-letter ISO-639 code.</param>
+		/// <param name="country">Uppercase two-letter ISO-3166 code.</param>
+		/// <param name="variant">Uppercase vendor and browser specific code.</param>
 		public Locale(string language, string country, string variant):
 			this (language, country, variant, null)
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Locale"/> class.
+		/// </summary>
+		/// <param name="language">Lowercase two-letter or three-letter ISO-639 code.</param>
+		/// <param name="country">Uppercase two-letter ISO-3166 code.</param>
+		/// <param name="variant">Uppercase vendor and browser specific code.</param>
+		/// <param name="keywordsAndValues">A string consisting of keyword/values pairs, such as "collation=phonebook;currency=euro"</param>
 		public Locale(string language, string country, string variant, string keywordsAndValues)
 		{
 			var bldr = new StringBuilder();
@@ -58,6 +74,9 @@ namespace Icu
 			Id = Canonicalize(bldr.ToString());
 		}
 
+		/// <summary>
+		/// Clone this object. (Not Implemented.)
+		/// </summary>
 		public object Clone()
 		{
 			throw new NotImplementedException();
@@ -92,16 +111,26 @@ namespace Icu
 			get { return GetString(NativeMethods.uloc_getCountry, Id); }
 		}
 
+		/// <summary>
+		/// Gets the variant code for the Locale.
+		/// </summary>
 		public string Variant
 		{
 			get { return GetString(NativeMethods.uloc_getVariant, Id); }
 		}
 
+		/// <summary>
+		/// Gets the full name for the specified locale.
+		/// </summary>
 		public string Name
 		{
 			get { return GetString(NativeMethods.uloc_getName, Id); }
 		}
 
+		/// <summary>
+		/// Gets the full name for the specified locale, like <see cref="Name"/>,
+		/// but without keywords.
+		/// </summary>
 		public string BaseName
 		{
 			get { return GetString(NativeMethods.uloc_getBaseName, Id); }
@@ -123,46 +152,77 @@ namespace Icu
 			get { return Marshal.PtrToStringAnsi(NativeMethods.uloc_getISO3Country(Id)); }
 		}
 
+		/// <summary>
+		/// Gets the Win32 LCID value for the specified locale.
+		/// </summary>
 		public int Lcid
 		{
 			get { return NativeMethods.uloc_getLCID(Id); }
 		}
 
+		/// <summary>
+		/// Gets the language for the UI's locale.
+		/// </summary>
 		public string DisplayLanguage
 		{
 			get { return GetDisplayLanguage(new Locale().Id); }
 		}
 
+		/// <summary>
+		/// Gets the language name suitable for display for the specified locale
+		/// </summary>
+		/// <param name="displayLocale">The display locale</param>
 		public string GetDisplayLanguage(Locale displayLocale)
 		{
 			return GetString(NativeMethods.uloc_getDisplayLanguage, Id, displayLocale.Id);
 		}
 
+		/// <summary>
+		/// Gets the country for the UI's locale.
+		/// </summary>
 		public string DisplayCountry
 		{
 			get { return GetDisplayCountry(new Locale().Id); }
 		}
 
+		/// <summary>
+		/// Gets the country name suitable for display for the specified locale.
+		/// </summary>
+		/// <param name="displayLocale">The display locale</param>
 		public string GetDisplayCountry(Locale displayLocale)
 		{
 			return GetString(NativeMethods.uloc_getDisplayCountry, Id, displayLocale.Id);
 		}
 
+		/// <summary>
+		/// Gets the full name for the UI's locale.
+		/// </summary>
 		public string DisplayName
 		{
 			get { return GetDisplayName(new Locale().Id); }
 		}
 
+		/// <summary>
+		/// Gets the full name suitable for display for the specified locale.
+		/// </summary>
+		/// <param name="displayLocale">The display locale</param>
 		public string GetDisplayName(Locale displayLocale)
 		{
 			return GetString(NativeMethods.uloc_getDisplayName, Id, displayLocale.Id);
 		}
 
+		/// <summary>
+		/// Gets the Locale's <see cref="Id"/> as a string.
+		/// </summary>
+		/// <returns></returns>
 		public override string ToString()
 		{
 			return Id;
 		}
 
+		/// <summary>
+		/// Gets a list of all available locales.
+		/// </summary>
 		public static List<Locale> AvailableLocales
 		{
 			get
@@ -174,6 +234,10 @@ namespace Icu
 			}
 		}
 
+		/// <summary>
+		/// Creates a Locale with the given Locale id.
+		/// </summary>
+		/// <param name="localeId">Locale id</param>
 		public static implicit operator Locale(string localeId)
 		{
 			return new Locale(localeId);

--- a/source/icu.net/Normalizer.cs
+++ b/source/icu.net/Normalizer.cs
@@ -5,6 +5,9 @@ using System.Runtime.InteropServices;
 
 namespace Icu
 {
+	/// <summary>
+	/// Unicode normalization functionality for standard Unicode normalization or for using custom mapping tables.
+	/// </summary>
 	public class Normalizer
 	{
 		/// <summary>

--- a/source/icu.net/ParseError.cs
+++ b/source/icu.net/ParseError.cs
@@ -5,6 +5,9 @@ using System.Runtime.InteropServices;
 
 namespace Icu
 {
+	/// <summary>
+	/// Used to return detailed information about parsing errors.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
 	public struct ParseError
 	{
@@ -35,11 +38,20 @@ namespace Icu
 		[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 16)]
 		public string PostContext;
 
+		/// <summary>
+		/// Gets a string representation of all the parsing errors.
+		/// </summary>
+		/// <returns></returns>
 		public override string ToString()
 		{
 			return ToString(string.Empty);
 		}
 
+		/// <summary>
+		/// Gets a string representation of the given rules with lines and offsets.
+		/// </summary>
+		/// <param name="rules">Rules</param>
+		/// <returns></returns>
 		public string ToString(string rules)
 		{
 			if (rules == null)

--- a/source/icu.net/ParseErrorException.cs
+++ b/source/icu.net/ParseErrorException.cs
@@ -12,6 +12,12 @@ namespace Icu
 		private readonly ParseError _error;
 		private readonly string _rules;
 
+		/// <summary>
+		/// Creates a exception with the given message, error and rules used.
+		/// </summary>
+		/// <param name="message">Message to add with exception.</param>
+		/// <param name="error">ParseError containing detailed error information.</param>
+		/// <param name="rules">Rules resulting in parse error.</param>
 		public ParseErrorException(string message, ParseError error, string rules)
 			: base(message)
 		{
@@ -24,12 +30,32 @@ namespace Icu
 			_rules = rules;
 		}
 
+		/// <summary>
+		/// Line that the error occured at.
+		/// </summary>
 		public int Line { get { return _error.Line; } }
+		/// <summary>
+		/// Gets the offset in the line that the syntax error is at.
+		/// </summary>
 		public int Offset { get { return _error.Offset; } }
+		/// <summary>
+		/// Textual context before the error or empty if there is none.
+		/// </summary>
 		public string PreContext { get { return _error.PreContext; } }
+		/// <summary>
+		/// The error itself or textual information after the error. Empty string
+		/// if there is none.
+		/// </summary>
 		public string PostContext { get { return _error.PostContext; } }
+		/// <summary>
+		/// Gets the rule that resulted in the error.
+		/// </summary>
 		public string Rules { get { return _rules; } }
 
+		/// <summary>
+		/// Gets a string representation of the exception message with rule and
+		/// its line and offset information.
+		/// </summary>
 		public override string ToString()
 		{
 			return Message + Environment.NewLine + _error.ToString(_rules);

--- a/source/icu.net/RuleBasedBreakIterator.cs
+++ b/source/icu.net/RuleBasedBreakIterator.cs
@@ -8,29 +8,31 @@ namespace Icu
 {
 	/// <summary>
 	/// A subclass of BreakIterator whose behavior is specified using a list of rules.
-	/// Instances of this class are most commonly created by the factory methods of
-	/// <see cref="BreakIterator.CreateWordInstance(Locale, string)"/>,
-	/// <see cref="BreakIterator.CreateLineInstance(Locale, string)"/> etc.,
+	/// Instances of this class are most commonly created by the factory methods
+	/// <see cref="BreakIterator.CreateWordInstance(Locale)"/>,
+	/// <see cref="BreakIterator.CreateLineInstance(Locale)"/>, etc.
 	/// and then used via the abstract API in class BreakIterator
 	/// </summary>
 	public class RuleBasedBreakIterator : BreakIterator
 	{
 		private readonly UBreakIteratorType _iteratorType;
 		private readonly string _rules = null;
+		private readonly Locale _locale = DefaultLocale;
 
 		private bool _disposingValue = false; // To detect redundant calls
 		private IntPtr _breakIterator = IntPtr.Zero;
+		private string _text;
+		private int _currentIndex = 0;
+		private TextBoundary[] _textBoundaries = new TextBoundary[0];
 
 		/// <summary>
 		/// Default RuleStatus vector returns 0.
 		/// </summary>
 		protected readonly static int[] EmptyRuleStatusVector = new int[] { 0 };
+		/// <summary>
+		/// The default locale.
+		/// </summary>
 		protected readonly static Locale DefaultLocale = new Locale();
-
-		protected int _currentIndex = 0;
-		protected TextBoundary[] _textBoundaries = new TextBoundary[0];
-		protected string _text;
-		protected readonly Locale _locale = DefaultLocale;
 
 		/// <summary>
 		/// Creates a BreakIterator with the given BreakIteratorType and Locale.
@@ -78,7 +80,7 @@ namespace Icu
 
 		/// <summary>
 		/// Determine the most recently-returned text boundary.
-		/// Returns <see cref="DONE"/> if there are no boundaries left to return.
+		/// Returns <see cref="BreakIterator.DONE"/> if there are no boundaries left to return.
 		/// </summary>
 		public override int Current
 		{
@@ -366,6 +368,10 @@ namespace Icu
 			return _textBoundaries[_currentIndex].RuleStatusVector;
 		}
 
+		/// <summary>
+		/// Sets an existing iterator to point to a new piece of text. 
+		/// </summary>
+		/// <param name="text">New text</param>
 		public override void SetText(string text)
 		{
 			if (text == null)
@@ -556,6 +562,9 @@ namespace Icu
 			}
 		}
 
+		/// <summary>
+		/// Disposes of all unmanaged resources used by RulesBasedBreakIterator
+		/// </summary>
 		~RuleBasedBreakIterator()
 		{
 			Dispose(false);
@@ -569,10 +578,33 @@ namespace Icu
 		/// </summary>
 		protected struct TextBoundary
 		{
+			/// <summary>
+			/// Gets the offset within the text of the boundary.
+			/// </summary>
 			public readonly int Offset;
+			/// <summary>
+			/// Gets the rule that was used to determine the boundary. Possible
+			/// values are from: <see cref="BreakIterator.ULineBreakTag"/>,
+			/// <see cref="BreakIterator.UWordBreak"/>, or <see cref="BreakIterator.USentenceBreakTag"/>
+			/// </summary>
+			/// <remarks>
+			/// If there are more than one rule that determined the boundary,
+			/// returns the numerically largest value from <see cref="RuleStatusVector"/>.
+			/// More information: http://userguide.icu-project.org/boundaryanalysis#TOC-Rule-Status-Values
+			/// </remarks>
 			public readonly int RuleStatus;
+			/// <summary>
+			/// Gets the set of rules used to determine the boundary. Possible
+			/// values are from: <see cref="BreakIterator.ULineBreakTag"/>,
+			/// <see cref="BreakIterator.UWordBreak"/>, or <see cref="BreakIterator.USentenceBreakTag"/>
+			/// </summary>
 			public readonly int[] RuleStatusVector;
 
+			/// <summary>
+			/// Creates a text boundary with the given offset and rule status vector.
+			/// </summary>
+			/// <param name="index">Offset in text of the boundary.</param>
+			/// <param name="ruleStatusVector">Rule status vector of boundary.</param>
 			public TextBoundary(int index, int[] ruleStatusVector)
 			{
 				Offset = index;

--- a/source/icu.net/UnicodeSet.cs
+++ b/source/icu.net/UnicodeSet.cs
@@ -6,6 +6,9 @@ using System.Runtime.InteropServices;
 
 namespace Icu
 {
+	/// <summary>
+	/// A mutable set of Unicode characters and multicharacter strings.
+	/// </summary>
 	public static class UnicodeSet
 	{
 		/// <summary>

--- a/source/icu.net/UnicodeString.cs
+++ b/source/icu.net/UnicodeString.cs
@@ -5,6 +5,11 @@ using System.Runtime.InteropServices;
 
 namespace Icu
 {
+	/// <summary>
+	/// UnicodeString is a string class that stores Unicode characters directly
+	/// and provides similar functionality as the Java String and
+	/// StringBuffer/StringBuilder classes.
+	/// </summary>
 	public class UnicodeString
 	{
 
@@ -22,6 +27,13 @@ namespace Icu
 			return ToLower(src, locale.Id);
 		}
 
+		/// <summary>
+		/// Convert the characters in this to lower case following the
+		/// conventions of a specific locale.
+		/// </summary>
+		/// <param name="src">String to convert.</param>
+		/// <param name="locale">The locale to consider, or "" for the root
+		/// locale or NULL for the default locale.</param>
 		public static string ToLower(string src, string locale)
 		{
 			if (src == null)
@@ -62,14 +74,20 @@ namespace Icu
 		/// Convert the string to upper case, using the convention of the specified locale.
 		/// This may be null for the universal locale, or "" for a 'root' locale (whatever that means).
 		/// </summary>
-		/// <param name="src"></param>
-		/// <param name="locale"></param>
-		/// <returns></returns>
+		/// <param name="src">String to convert.</param>
+		/// <param name="locale">The locale containing the conventions to use.</param>
 		public static string ToUpper(string src, Locale locale)
 		{
 			return ToUpper(src, locale.Id);
 		}
 
+		/// <summary>
+		/// Convert the characters in this to UPPER CASE following the
+		/// conventions of a specific locale.
+		/// </summary>
+		/// <param name="src">String to convert.</param>
+		/// <param name="locale">The locale to consider, or "" for the root 
+		/// locale or NULL for the default locale.</param>
 		public static string ToUpper(string src, string locale)
 		{
 			if (src == null)
@@ -118,6 +136,16 @@ namespace Icu
 			return ToTitle(src, locale.Id);
 		}
 
+		/// <summary>
+		/// Titlecase a string. Casing is locale-dependent and context-sensitive.
+		/// Titlecasing uses a break iterator to find the first characters of
+		/// words that are to be titlecased.It titlecases those characters and
+		/// lowercases all others.
+		/// </summary>
+		/// <param name="src">The original string</param>
+		/// <param name="locale">The locale to consider, or "" for the root
+		/// locale or NULL for the default locale.</param>
+		/// <returns></returns>
 		public static string ToTitle(string src, string locale)
 		{
 			if (src == null)
@@ -157,6 +185,15 @@ namespace Icu
 			}
 		}
 
+		/// <summary>
+		/// Titlecase a string and then normalizes the string using the given
+		/// normalization mode.
+		/// </summary>
+		/// <param name="src">The original string.</param>
+		/// <param name="locale">The locale to consider, or "" for the root
+		/// locale or NULL for the default locale.</param>
+		/// <param name="normMode">Normalization mode to apply to titlecased string.</param>
+		/// <returns></returns>
 		public static string ToTitle(string src, string locale, Normalizer.UNormalizationMode normMode)
 		{
 			src = Normalizer.Normalize(src, Normalizer.UNormalizationMode.UNORM_NFC);

--- a/source/icu.net/UnicodeString.cs
+++ b/source/icu.net/UnicodeString.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 SIL International
+﻿// Copyright (c) 2013 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System;
 using System.Runtime.InteropServices;
@@ -28,8 +28,8 @@ namespace Icu
 		}
 
 		/// <summary>
-		/// Convert the characters in this to lower case following the
-		/// conventions of a specific locale.
+		/// Convert the characters in <paramref name="src"/> to lower case
+		/// following the conventions of a specific locale.
 		/// </summary>
 		/// <param name="src">String to convert.</param>
 		/// <param name="locale">The locale to consider, or "" for the root
@@ -82,11 +82,11 @@ namespace Icu
 		}
 
 		/// <summary>
-		/// Convert the characters in this to UPPER CASE following the
-		/// conventions of a specific locale.
+		/// Convert the characters in <paramref name="src"/> to UPPER CASE
+		/// following the conventions of a specific locale.
 		/// </summary>
 		/// <param name="src">String to convert.</param>
-		/// <param name="locale">The locale to consider, or "" for the root 
+		/// <param name="locale">The locale to consider, or "" for the root
 		/// locale or NULL for the default locale.</param>
 		public static string ToUpper(string src, string locale)
 		{
@@ -139,7 +139,7 @@ namespace Icu
 		/// <summary>
 		/// Titlecase a string. Casing is locale-dependent and context-sensitive.
 		/// Titlecasing uses a break iterator to find the first characters of
-		/// words that are to be titlecased.It titlecases those characters and
+		/// words that are to be titlecased. It titlecases those characters and
 		/// lowercases all others.
 		/// </summary>
 		/// <param name="src">The original string</param>

--- a/source/icu.net/VersionInfo.cs
+++ b/source/icu.net/VersionInfo.cs
@@ -5,13 +5,32 @@ using System.Runtime.InteropServices;
 
 namespace Icu
 {
+	/// <summary>
+	/// Struct representing Version information.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public struct VersionInfo
 	{
+		/// <summary>
+		/// Major version number.
+		/// </summary>
 		public Byte Major;
+		/// <summary>
+		/// Minor version number.
+		/// </summary>
 		public Byte Minor;
+		/// <summary>
+		/// Milli portion of version number
+		/// </summary>
 		public Byte Milli;
+		/// <summary>
+		/// Micro portion of version number.
+		/// </summary>
 		public Byte Micro;
+		/// <summary>
+		/// Gets string representation of Version as: Major.Minor.Milli
+		/// or Major.Minor.Milli.Micro
+		/// </summary>
 		public override string ToString()
 		{
 			// Only include Milli and Micro portions if they're non-zero


### PR DESCRIPTION
I recently pulled from master and I was getting around 280+ [CS1591 ](https://msdn.microsoft.com/en-us/library/zk18c1w9.aspx?f=255&MSPPError=-2147217396) warnings: "Missing XML comment for publicly visible type or member".  

This PR:

* Fixes all those warnings by adding documentation based on documentation in [ICU4C](http://icu-project.org/apiref/icu4c/)
* Adds [Obsolete] to properties/enum values that have values that are deprecated. (ie. [Collator.HiraganaQuaternary](https://github.com/sillsdev/icu-dotnet/compare/master...conniey:fixWarnings?expand=1#diff-4edbc99f1affddcfddc80262f12a09a6R49), [Character.BINARY_LIMIT](https://github.com/sillsdev/icu-dotnet/compare/master...conniey:fixWarnings?expand=1#diff-1326ee295886b5bf056871756b1c2281R243), etc.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/29)
<!-- Reviewable:end -->
