### PR TITLE
Adjust to nuget3 compatible Icu4c packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Assembly marked as CLSCompliant (#33)
+- additionally look in lib/x86 and lib/x64 for ICU binaries
 
 ## [2.1.0] - 2017-03-17
 

--- a/source/icu.net/NativeMethods.cs
+++ b/source/icu.net/NativeMethods.cs
@@ -164,14 +164,21 @@ namespace Icu
 		{
 			if (IcuVersion <= 0)
 			{
-				// Look for ICU binaries in x86/x64 subdirectory first
+				// Look for ICU binaries in lib/x86 or lib/x64 subdirectory first
+				var platformSubDir = IsRunning64Bit ? "x64" : "x86";
 				if (!CheckDirectoryForIcuBinaries(
-					Path.Combine(DirectoryOfThisAssembly, IsRunning64Bit ? "x64" : "x86"),
+					Path.Combine(DirectoryOfThisAssembly, "lib", platformSubDir),
 					libraryName))
 				{
-					// otherwise check the current directory
-					CheckDirectoryForIcuBinaries(DirectoryOfThisAssembly, libraryName);
-					// If we don't find it here we rely on it being in the PATH somewhere...
+					// next try just x86/x64 subdirectory
+					if (!CheckDirectoryForIcuBinaries(
+						Path.Combine(DirectoryOfThisAssembly, platformSubDir),
+						libraryName))
+					{
+						// otherwise check the current directory
+						CheckDirectoryForIcuBinaries(DirectoryOfThisAssembly, libraryName);
+						// If we don't find it here we rely on it being in the PATH somewhere...
+					}
 				}
 			}
 			var handle = GetIcuLibHandle(libraryName, IcuVersion > 0 ? IcuVersion : maxIcuVersion);


### PR DESCRIPTION
Look in lib/x86 and lib/x64 for ICU binaries in addition to
x86 and x64.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/39)
<!-- Reviewable:end -->
