### PR TITLE
Fix buffer overflow errors in Normalize()

### DIFF
--- a/source/icu.net.tests/NormalizerTests.cs
+++ b/source/icu.net.tests/NormalizerTests.cs
@@ -28,5 +28,15 @@ namespace Icu.Tests
 		{
 			return Normalizer.IsNormalized(src, expectNormalizationMode);
 		}
+
+		// https://github.com/sillsdev/icu-dotnet/issues/47
+		[TestCase("⒆⑵Ⓖ⒭⓫⒄⒱ⓞ")]
+		[TestCase("㎞㌻㌵㍑㍑")]
+		[TestCase("㌎㍊㌵㌇㌿")]
+		public void Normalize_NoOverflowError(string input)
+		{
+			Assert.That(() => Normalizer.Normalize(input, Normalizer.UNormalizationMode.UNORM_NFKC),
+				Throws.Nothing);
+		}
 	}
 }

--- a/source/icu.net/NativeMethods.cs
+++ b/source/icu.net/NativeMethods.cs
@@ -881,6 +881,19 @@ namespace Icu
 				Normalizer.UNormalizationMode mode, out ErrorCode errorCode);
 
 			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			internal delegate IntPtr unorm2_getInstanceDelegate(IntPtr packageName,
+				[MarshalAs(UnmanagedType.LPStr)] string name,
+				Normalizer.UNormalization2Mode mode, out ErrorCode errorCode);
+
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			internal delegate int unorm2_normalizeDelegate(IntPtr norm2, string source,
+				int sourceLength, IntPtr dest, int capacity, ref ErrorCode errorCode);
+
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			internal delegate byte unorm2_isNormalizedDelegate(IntPtr norm2, string source,
+				int sourceLength, out ErrorCode errorCode);
+
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
 			internal delegate IntPtr ubrk_openDelegate(BreakIterator.UBreakIteratorType type,
 				string locale, string text, int textLength, out ErrorCode errorCode);
 
@@ -1017,6 +1030,9 @@ namespace Icu
 			internal u_strToUpperDelegate u_strToUpper;
 			internal unorm_normalizeDelegate _unorm_normalize;
 			internal unorm_isNormalizedDelegate _unorm_isNormalized;
+			internal unorm2_getInstanceDelegate _unorm2_getInstance;
+			internal unorm2_normalizeDelegate _unorm2_normalize;
+			internal unorm2_isNormalizedDelegate _unorm2_isNormalized;
 			internal ubrk_openDelegate ubrk_open;
 			internal ubrk_openRulesDelegate ubrk_openRules;
 			internal ubrk_closeDelegate ubrk_close;
@@ -1560,6 +1576,62 @@ namespace Icu
 			if (Methods._unorm_isNormalized == null)
 				Methods._unorm_isNormalized = GetMethod<MethodsContainer.unorm_isNormalizedDelegate>(IcuCommonLibHandle, "unorm_isNormalized");
 			return Methods._unorm_isNormalized(source, sourceLength, mode, out errorCode);
+		}
+
+		#endregion normalize
+
+		#region normalize2
+
+		/// <summary>
+		/// Returns a UNormalizer2 instance which uses the specified data file (packageName/name
+		/// similar to ucnv_openPackage() and ures_open()/ResourceBundle) and which composes or
+		/// decomposes text according to the specified mode.
+		/// </summary>
+		public static IntPtr unorm2_getInstance(IntPtr packageName, string name,
+			Normalizer.UNormalization2Mode mode, out ErrorCode errorCode)
+		{
+			if (Methods._unorm2_getInstance == null)
+			{
+				Methods._unorm2_getInstance = GetMethod<MethodsContainer.unorm2_getInstanceDelegate>(
+					IcuCommonLibHandle, "unorm2_getInstance");
+			}
+			return Methods._unorm2_getInstance(packageName, name, mode, out errorCode);
+		}
+
+		/// <summary>
+		/// Normalize a string according to the given mode and options.
+		/// </summary>
+		public static int unorm2_normalize(IntPtr norm2, string source, int sourceLength,
+			IntPtr result, int resultLength, out ErrorCode errorCode)
+		{
+			if (Methods._unorm2_normalize == null)
+			{
+				Methods._unorm2_normalize = GetMethod<MethodsContainer.unorm2_normalizeDelegate>(
+					IcuCommonLibHandle, "unorm2_normalize");
+			}
+			// Theoretically it should be unnecessary to initialize errorCode here. Instead we
+			// should be able to use `out` instead. However, there seems to be a bug somewhere:
+			// if this method gets called twice and errorCode != NoErrors, the error code won't
+			// get reset, even though the method seems to work without errors.
+			errorCode = ErrorCode.NoErrors;
+			return Methods._unorm2_normalize(norm2, source, sourceLength, result,
+				resultLength, ref errorCode);
+		}
+
+		// Note that ICU's UBool type is typedef to an 8-bit integer.
+
+		/// <summary>
+		/// Check whether a string is normalized according to the given mode and options.
+		/// </summary>
+		public static byte unorm2_isNormalized(IntPtr norm2, string source, int sourceLength,
+			out ErrorCode errorCode)
+		{
+			if (Methods._unorm2_isNormalized == null)
+			{
+				Methods._unorm2_isNormalized = GetMethod<MethodsContainer.unorm2_isNormalizedDelegate>(
+					IcuCommonLibHandle, "unorm2_isNormalized");
+			}
+			return Methods._unorm2_isNormalized(norm2, source, sourceLength, out errorCode);
 		}
 
 		#endregion normalize

--- a/source/icu.net/Normalizer.cs
+++ b/source/icu.net/Normalizer.cs
@@ -31,6 +31,27 @@ namespace Icu
 			UNORM_FCD = 6
 		}
 
+		internal enum UNormalization2Mode
+		{
+			UNORM2_COMPOSE = 0,
+			UNORM2_DECOMPOSE = 1,
+			UNORM2_FCD = 2,
+			UNORM2_COMPOSE_CONTIGUOUS = 3
+		}
+
+		private static IntPtr GetNormalizer(UNormalizationMode mode)
+		{
+			ErrorCode errorCode;
+			var ret = NativeMethods.unorm2_getInstance(IntPtr.Zero,
+				(mode == UNormalizationMode.UNORM_NFC || mode == UNormalizationMode.UNORM_NFD) ? "nfc" : "nfkc",
+				(mode == UNormalizationMode.UNORM_NFC || mode == UNormalizationMode.UNORM_NFKC) ?
+					UNormalization2Mode.UNORM2_COMPOSE : UNormalization2Mode.UNORM2_DECOMPOSE,
+				out errorCode);
+			if (errorCode != ErrorCode.NoErrors)
+				throw new Exception("Normalizer.Normalize() failed with code " + errorCode);
+			return ret;
+		}
+
 		/// <summary>
 		/// Normalize the string according to the given mode.
 		/// </summary>
@@ -42,25 +63,26 @@ namespace Icu
 			if (string.IsNullOrEmpty(src))
 				return string.Empty;
 
-			int length = src.Length + 10;
-			IntPtr resPtr = Marshal.AllocCoTaskMem(length * 2);
+			var length = src.Length + 10;
+			var resPtr = Marshal.AllocCoTaskMem(length * 2);
 			try
 			{
 				ErrorCode err;
-				int outLength = NativeMethods.unorm_normalize(src, src.Length, mode, 0, resPtr, length, out err);
+				var normalizer = GetNormalizer(mode);
+				var outLength = NativeMethods.unorm2_normalize(normalizer, src, src.Length, resPtr, length, out err);
 				if (err > 0 && err != ErrorCode.BUFFER_OVERFLOW_ERROR)
 					throw new Exception("Normalizer.Normalize() failed with code " + err);
 				if (outLength >= length)
 				{
 					Marshal.FreeCoTaskMem(resPtr);
-					length = outLength + 1;		// allow room for the terminating NUL (FWR-505)
+					length = outLength + 1; // allow room for the terminating NUL (FWR-505)
 					resPtr = Marshal.AllocCoTaskMem(length * 2);
-					NativeMethods.unorm_normalize(src, src.Length, mode, 0, resPtr, length, out err);
+					outLength = NativeMethods.unorm2_normalize(normalizer, src, src.Length, resPtr, length, out err);
 				}
 				if (err > 0)
 					throw new Exception("Normalizer.Normalize() failed with code " + err);
 
-				string result = Marshal.PtrToStringUni(resPtr);
+				var result = Marshal.PtrToStringUni(resPtr);
 				// Strip any garbage left over at the end of the string.
 				if (err == ErrorCode.STRING_NOT_TERMINATED_WARNING && result != null)
 					return result.Substring(0, outLength);
@@ -86,7 +108,7 @@ namespace Icu
 				return true;
 
 			ErrorCode err;
-			byte fIsNorm = NativeMethods.unorm_isNormalized(src, src.Length, mode, out err);
+			var fIsNorm = NativeMethods.unorm2_isNormalized(GetNormalizer(mode), src, src.Length, out err);
 			if (err != ErrorCode.NoErrors)
 				throw new Exception("Normalizer.IsNormalized() failed with code " + err);
 			return fIsNorm != 0;


### PR DESCRIPTION
This change also starts to use unorm2 methods instead of the deprecated
unorm* ones. The main change to fix the buffer overflow however is to
reset the errorcode variable (Mono bug?).

This fixes issue #47.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/49)
<!-- Reviewable:end -->
