### PR TITLE
 Check for ICU in new location (#51)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/Palaso.BuildTasks.dll
 build/Dependencies.files
 build/NuGet.exe
+build/nuget.exe
 lib/
 output/
 obj/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- fix buffer overflow in Normalize() (#47)
+
 ### Changed
 
 - Assembly marked as CLSCompliant (#33)
-- additionally look in lib/x86 and lib/x64 for ICU binaries
+- additionally look in lib/x86 and lib/x64 as well as lib/win-*
+  and lib/linux-* for ICU binaries (#51)
 - Add minimal support of regular expressions (#32, MURATA Makoto)
 
 ## [2.1.0] - 2017-03-17

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ ansiColor('xterm') {
 			try {
 				parallel('Windows build': {
 					node('windows && supported') {
-						def msbuild = tool 'msbuild12'
+						def msbuild = tool 'msbuild15'
 
 						stage('Checkout Win') {
 							checkout scm

--- a/source/icu.net.tests/NativeMethodsTests.cs
+++ b/source/icu.net.tests/NativeMethodsTests.cs
@@ -25,24 +25,15 @@ namespace Icu.Tests
 			File.Copy(srcPath, Path.Combine(dstDir, fileName));
 		}
 
-		private static bool IsRunning64Bit
-		{
-			get { return IntPtr.Size == 8; }
-		}
+		private static bool IsRunning64Bit => IntPtr.Size == 8;
 
 		private static string ArchSubdir
 		{
 			get { return IsRunning64Bit ? "x64" : "x86"; }
 		}
 
-		private static string OutputDirectory
-		{
-			get
-			{
-				return Path.GetDirectoryName(
-					new Uri(typeof(NativeMethodsTests).Assembly.CodeBase).LocalPath);
-			}
-		}
+		private static string OutputDirectory => Path.GetDirectoryName(
+			new Uri(typeof(NativeMethodsTests).Assembly.CodeBase).LocalPath);
 
 		private static string IcuDirectory
 		{
@@ -70,11 +61,11 @@ namespace Icu.Tests
 			}
 		}
 
-		private void CopyMinimalIcuFiles(string targetDir)
+		private static void CopyMinimalIcuFiles(string targetDir)
 		{
-			CopyFile(Path.Combine(IcuDirectory, string.Format("icudt{0}.dll", MinIcuLibraryVersionMajor)), targetDir);
-			CopyFile(Path.Combine(IcuDirectory, string.Format("icuin{0}.dll", MinIcuLibraryVersionMajor)), targetDir);
-			CopyFile(Path.Combine(IcuDirectory, string.Format("icuuc{0}.dll", MinIcuLibraryVersionMajor)), targetDir);
+			CopyFile(Path.Combine(IcuDirectory, $"icudt{MinIcuLibraryVersionMajor}.dll"), targetDir);
+			CopyFile(Path.Combine(IcuDirectory, $"icuin{MinIcuLibraryVersionMajor}.dll"), targetDir);
+			CopyFile(Path.Combine(IcuDirectory, $"icuuc{MinIcuLibraryVersionMajor}.dll"), targetDir);
 		}
 
 		[SetUp]
@@ -87,8 +78,7 @@ namespace Icu.Tests
 			CopyFile(Path.Combine(sourceDir, "icu.net.dll"), _tmpDir);
 
 			_pathEnvironmentVariable = Environment.GetEnvironmentVariable("PATH");
-			var path = string.Format("{0}{1}{2}", IcuDirectory, Path.PathSeparator,
-				_pathEnvironmentVariable);
+			var path = $"{IcuDirectory}{Path.PathSeparator}{_pathEnvironmentVariable}";
 			Environment.SetEnvironmentVariable("PATH", path);
 		}
 

--- a/source/icu.net.tests/NativeMethodsTests.cs
+++ b/source/icu.net.tests/NativeMethodsTests.cs
@@ -27,18 +27,16 @@ namespace Icu.Tests
 
 		private static bool IsRunning64Bit => IntPtr.Size == 8;
 
-		private static string ArchSubdir
+		private static string GetArchSubdir(string prefix = "")
 		{
-			get { return IsRunning64Bit ? "x64" : "x86"; }
+			var archSubdir = IsRunning64Bit ? "x64" : "x86";
+			return $"{prefix}{archSubdir}";
 		}
 
 		private static string OutputDirectory => Path.GetDirectoryName(
 			new Uri(typeof(NativeMethodsTests).Assembly.CodeBase).LocalPath);
 
-		private static string IcuDirectory
-		{
-			get { return Path.Combine(OutputDirectory, "lib", ArchSubdir); }
-		}
+		private static string IcuDirectory => Path.Combine(OutputDirectory, "lib", GetArchSubdir("win-"));
 
 		private string RunTestHelper(string workDir, string exeDir = null)
 		{
@@ -116,10 +114,11 @@ namespace Icu.Tests
 			Assert.That(RunTestHelper(Path.GetTempPath()), Is.EqualTo(MinIcuLibraryVersion));
 		}
 
-		[Test]
-		public void LoadIcuLibrary_LoadLocalVersionFromArchSubDir()
+		[TestCase("")]
+		[TestCase("win-")]
+		public void LoadIcuLibrary_LoadLocalVersionFromArchSubDir(string prefix)
 		{
-			var targetDir = Path.Combine(_tmpDir, ArchSubdir);
+			var targetDir = Path.Combine(_tmpDir, GetArchSubdir(prefix));
 			Directory.CreateDirectory(targetDir);
 			CopyMinimalIcuFiles(targetDir);
 			Assert.That(RunTestHelper(_tmpDir), Is.EqualTo(MinIcuLibraryVersion));

--- a/source/icu.net.tests/icu.net.tests.csproj
+++ b/source/icu.net.tests/icu.net.tests.csproj
@@ -190,9 +190,9 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Icu4c.Win.Min.58.2.18-beta\build\Icu4c.Win.Min.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Icu4c.Win.Min.58.2.18-beta\build\Icu4c.Win.Min.targets'))" />
-    <Error Condition="!Exists('..\packages\Icu4c.Win.Full.Lib.59.1.7-beta\build\Icu4c.Win.Full.Lib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Icu4c.Win.Full.Lib.59.1.7-beta\build\Icu4c.Win.Full.Lib.targets'))" />
+    <Error Condition="!Exists('..\packages\Icu4c.Win.Min.58.2.20-beta\build\Icu4c.Win.Min.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Icu4c.Win.Min.58.2.20-beta\build\Icu4c.Win.Min.targets'))" />
+    <Error Condition="!Exists('..\packages\Icu4c.Win.Full.Lib.59.1.10-beta\build\Icu4c.Win.Full.Lib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Icu4c.Win.Full.Lib.59.1.10-beta\build\Icu4c.Win.Full.Lib.targets'))" />
   </Target>
-  <Import Project="..\packages\Icu4c.Win.Min.58.2.18-beta\build\Icu4c.Win.Min.targets" Condition="Exists('..\packages\Icu4c.Win.Min.58.2.18-beta\build\Icu4c.Win.Min.targets')" />
-  <Import Project="..\packages\Icu4c.Win.Full.Lib.59.1.7-beta\build\Icu4c.Win.Full.Lib.targets" Condition="Exists('..\packages\Icu4c.Win.Full.Lib.59.1.7-beta\build\Icu4c.Win.Full.Lib.targets')" />
+  <Import Project="..\packages\Icu4c.Win.Min.58.2.20-beta\build\Icu4c.Win.Min.targets" Condition="Exists('..\packages\Icu4c.Win.Min.58.2.20-beta\build\Icu4c.Win.Min.targets')" />
+  <Import Project="..\packages\Icu4c.Win.Full.Lib.59.1.10-beta\build\Icu4c.Win.Full.Lib.targets" Condition="Exists('..\packages\Icu4c.Win.Full.Lib.59.1.10-beta\build\Icu4c.Win.Full.Lib.targets')" />
 </Project>

--- a/source/icu.net.tests/packages.config
+++ b/source/icu.net.tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Icu4c.Win.Full.Lib" version="59.1.7-beta" targetFramework="net40" />
-  <package id="Icu4c.Win.Min" version="58.2.18-beta" targetFramework="net40" />
+  <package id="Icu4c.Win.Full.Lib" version="59.1.10-beta" targetFramework="net40" />
+  <package id="Icu4c.Win.Min" version="58.2.20-beta" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
   <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net40" />
 </packages>

--- a/source/icu.net/NativeMethods.cs
+++ b/source/icu.net/NativeMethods.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 SIL International
+﻿// Copyright (c) 2013-2017 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System;
 using System.Diagnostics;
@@ -23,14 +23,12 @@ namespace Icu
 			if (minVersion < MinIcuVersionDefault || minVersion > MaxIcuVersionDefault)
 			{
 				throw new ArgumentOutOfRangeException("minVersion",
-					string.Format("supported ICU versions are between {0} and {1}",
-					MinIcuVersionDefault, MaxIcuVersionDefault));
+					$"supported ICU versions are between {MinIcuVersionDefault} and {MaxIcuVersionDefault}");
 			}
 			if (maxVersion < MinIcuVersionDefault || maxVersion > MaxIcuVersionDefault)
 			{
 				throw new ArgumentOutOfRangeException("maxVersion",
-					string.Format("supported ICU versions are between {0} and {1}",
-					MinIcuVersionDefault, MaxIcuVersionDefault));
+					$"supported ICU versions are between {MinIcuVersionDefault} and {MaxIcuVersionDefault}");
 			}
 			minIcuVersion = Math.Min(minVersion, maxVersion);
 			maxIcuVersion = Math.Max(minVersion, maxVersion);
@@ -80,10 +78,7 @@ namespace Icu
 		private static IntPtr _IcuCommonLibHandle;
 		private static IntPtr _IcuI18NLibHandle;
 
-		private static bool IsWindows
-		{
-			get { return Environment.OSVersion.Platform != PlatformID.Unix; }
-		}
+		private static bool IsWindows => Environment.OSVersion.Platform != PlatformID.Unix;
 
 		private static IntPtr IcuCommonLibHandle
 		{
@@ -114,10 +109,7 @@ namespace Icu
 			}
 		}
 
-		private static bool IsRunning64Bit
-		{
-			get { return Environment.Is64BitProcess; }
-		}
+		private static bool IsRunning64Bit => Environment.Is64BitProcess;
 
 		private static void AddDirectoryToSearchPath(string directory)
 		{
@@ -127,7 +119,7 @@ namespace Icu
 			{
 				var ldLibPath = Environment.GetEnvironmentVariable("LD_LIBRARY_PATH");
 				Environment.SetEnvironmentVariable("LD_LIBRARY_PATH",
-					string.Format("{0}:{1}", directory, ldLibPath));
+					$"{directory}:{ldLibPath}");
 			}
 		}
 
@@ -184,7 +176,7 @@ namespace Icu
 			var handle = GetIcuLibHandle(libraryName, IcuVersion > 0 ? IcuVersion : maxIcuVersion);
 			if (handle == IntPtr.Zero)
 			{
-				throw new FileLoadException(string.Format("Can't load ICU library (version {0})", IcuVersion),
+				throw new FileLoadException($"Can't load ICU library (version {IcuVersion})",
 					libraryName);
 			}
 			return handle;
@@ -198,13 +190,13 @@ namespace Icu
 			string libPath;
 			if (IsWindows)
 			{
-				var libName = string.Format("{0}{1}.dll", basename, icuVersion);
+				var libName = $"{basename}{icuVersion}.dll";
 				libPath = string.IsNullOrEmpty(_IcuPath) ? libName : Path.Combine(_IcuPath, libName);
 				handle = LoadLibrary(libPath);
 			}
 			else
 			{
-				var libName = string.Format("lib{0}.so.{1}", basename, icuVersion);
+				var libName = $"lib{basename}.so.{icuVersion}";
 				libPath = string.IsNullOrEmpty(_IcuPath) ? libName : Path.Combine(_IcuPath, libName);
 				handle = dlopen(libPath, RTLD_NOW);
 			}
@@ -246,7 +238,7 @@ namespace Icu
 
 		private static T GetMethod<T>(IntPtr handle, string methodName, bool missingInMinimal = false) where T: class
 		{
-			var versionedMethodName = string.Format("{0}_{1}", methodName, IcuVersion);
+			var versionedMethodName = $"{methodName}_{IcuVersion}";
 			var methodPointer = IsWindows ?
 				GetProcAddress(handle, versionedMethodName) :
 				dlsym(handle, versionedMethodName);
@@ -258,8 +250,8 @@ namespace Icu
 			if (missingInMinimal)
 			{
 				throw new MissingMemberException(
-					string.Format("Do you have the full version of ICU installed? " +
-					"The method '{0}' is not included in the minimal version of ICU.", methodName));
+					"Do you have the full version of ICU installed? " +
+					$"The method '{methodName}' is not included in the minimal version of ICU.");
 			}
 			return default(T);
 		}


### PR DESCRIPTION
The newest versions of icu4c put the binaries in win-x64/win-x86 to
allow the use in a WIX installer. On Linux we look in linux-64/
linux-x86 instead. This change looks in these new directories
in addition to the locations we looked previously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/52)
<!-- Reviewable:end -->
