### PR TITLE
Fix Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,13 @@ ansiColor('xterm') {
 						def msbuild = tool 'msbuild15'
 
 						stage('Checkout Win') {
-							checkout scm
+							checkout([
+								$class: 'GitSCM',
+								branches: scm.branches,
+								doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations,
+								extensions: [[$class: 'CloneOption', noTags: false]],
+								userRemoteConfigs: scm.userRemoteConfigs,
+							])
 						}
 
 						stage('Build Win') {
@@ -68,7 +74,13 @@ ansiColor('xterm') {
 				}, 'Linux': {
 					node('linux64 && !packager && ubuntu') {
 						stage('Checkout Linux') {
-							checkout scm
+							checkout([
+								$class: 'GitSCM',
+								branches: scm.branches,
+								doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations,
+								extensions: [[$class: 'CloneOption', noTags: false]],
+								userRemoteConfigs: scm.userRemoteConfigs,
+							])
 						}
 
 						stage('Build and Test Linux') {


### PR DESCRIPTION
We have to fetch the tags as well in order for GitVersion to work
correctly. This change re-enables that behavior. The behavior
changed with version 3.4.0 of the Jenkins Git plugin
(see https://issues.jenkins-ci.org/browse/JENKINS-45164).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/53)
<!-- Reviewable:end -->
