### PR TITLE
Add `Wrapper.Init()` method (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Add Wrapper.Init() method to allow initialization of ICU for
+  multi-threaded applications (#54)
+
 ### Fixed
 
 - Fix signature of u_charType (#54)

--- a/source/icu.net.tests/RegexMatcherTests.cs
+++ b/source/icu.net.tests/RegexMatcherTests.cs
@@ -10,7 +10,6 @@ namespace Icu.Tests
 	[Category("Regular Expression")]
 	class RegexMatcherTests
 	{
-		[Test]
 		[TestCase("c", ExpectedResult = true)]
 		[TestCase("abc", ExpectedResult = true)]
 		[TestCase("baabbac", ExpectedResult = true)]
@@ -19,20 +18,25 @@ namespace Icu.Tests
 		[TestCase("baabcc", ExpectedResult = false)]
 		public bool MatchSimpleTest(string text)
 		{
-			RegexMatcher rm = new RegexMatcher("(a|b)*c");
-			return rm.Matches(text);
+			using (var rm = new RegexMatcher("(a|b)*c"))
+			{
+				return rm.Matches(text);
+			}
 		}
-		[Test]
+
 		[TestCase("c", ExpectedResult = true)]
 		[TestCase("abc", ExpectedResult = true)]
 		[TestCase("baabbac", ExpectedResult = true)]
 		[TestCase(" c", ExpectedResult = false)]
 		public bool MatchWithCommentsAndSpace(string text)
 		{
-			RegexMatcher rm = new RegexMatcher("(?# space is ignored )(a | b)* c", RegexMatcher.URegexpFlag.COMMENTS);
-			return rm.Matches(text);
+			using (var rm = new RegexMatcher("(?# space is ignored )(a | b)* c",
+				RegexMatcher.URegexpFlag.COMMENTS))
+			{
+				return rm.Matches(text);
+			}
 		}
-		[Test]
+
 		[TestCase("a", "\\p{L}", ExpectedResult = true)]
 		[TestCase("a", "\\p{Lowercase_Letter}", ExpectedResult = true)]
 		[TestCase("\u3042", "\\p{Hiragana}", ExpectedResult = true)]
@@ -46,8 +50,10 @@ namespace Icu.Tests
 		[TestCase("D", "[ABC--DE]", ExpectedResult = false)]
 		public bool MatchAdvancedTest(string text, string regexp)
 		{
-			RegexMatcher rm = new RegexMatcher(regexp);
-			return rm.Matches(text);
+			using (var rm = new RegexMatcher(regexp))
+			{
+				return rm.Matches(text);
+			}
 		}
 }
 }

--- a/source/icu.net.tests/SetUpFixture.cs
+++ b/source/icu.net.tests/SetUpFixture.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+
+using NUnit.Framework;
+
+namespace Icu.Tests
+{
+	[SetUpFixture]
+	public class SetUpFixture
+	{
+		[SetUp]
+		public void RunBeforeAnyTests()
+		{
+			Wrapper.Init();
+		}
+
+		[TearDown]
+		public void RunAfterAnyTests()
+		{
+			Wrapper.Cleanup();
+		}
+	}
+}

--- a/source/icu.net.tests/icu.net.tests.csproj
+++ b/source/icu.net.tests/icu.net.tests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="LocaleTests.cs" />
     <Compile Include="CharacterTests.cs" />
     <Compile Include="RegexMatcherTests.cs" />
+    <Compile Include="SetUpFixture.cs" />
     <Compile Include="UnicodeStringTests.cs" />
     <Compile Include="UnicodeSetTests.cs" />
     <Compile Include="NormalizerTests.cs" />

--- a/source/icu.net/IcuWrapper.cs
+++ b/source/icu.net/IcuWrapper.cs
@@ -64,11 +64,26 @@ namespace Icu
 
 		#region Public wrappers around the ICU methods
 
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Initialize ICU. In multi-threaded applications this should be the first ICU method
+		/// that gets called, preferrably before starting multiple threads.
+		/// </summary>
+		/// <seealso href="http://userguide.icu-project.org/design#TOC-ICU-Initialization-and-Termination"/>
+		/// ------------------------------------------------------------------------------------
+		public static ErrorCode Init()
+		{
+			ErrorCode errorCode;
+			NativeMethods.u_init(out errorCode);
+			return errorCode;
+		}
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Cleans up the ICU files that could be locked
+		/// Cleans up the ICU files that could be locked. This should be the last ICU method
+		/// that gets called.
 		/// </summary>
+		/// <seealso href="http://userguide.icu-project.org/design#TOC-ICU-Initialization-and-Termination"/>
 		/// ------------------------------------------------------------------------------------
 		public static void Cleanup()
 		{

--- a/source/icu.net/NativeMethods.cs
+++ b/source/icu.net/NativeMethods.cs
@@ -110,6 +110,8 @@ namespace Icu
 
 		private static bool IsRunning64Bit => Environment.Is64BitProcess;
 
+		private static bool IsInitialized { get; set; }
+
 		private static void AddDirectoryToSearchPath(string directory)
 		{
 			if (IsWindows)
@@ -186,6 +188,8 @@ namespace Icu
 
 		private static IntPtr LoadIcuLibrary(string libraryName)
 		{
+			Trace.WriteLineIf(!IsInitialized, "WARNING: ICU is not initialized.");
+
 			if (IcuVersion <= 0)
 				LocateIcuLibrary(libraryName);
 
@@ -1066,6 +1070,7 @@ namespace Icu
 		/// <summary>get the name of an ICU code point</summary>
 		public static void u_init(out ErrorCode errorCode)
 		{
+			IsInitialized = true;
 			if (Methods.u_init == null)
 				Methods.u_init = GetMethod<MethodsContainer.u_initDelegate>(IcuCommonLibHandle, "u_init");
 			Methods.u_init(out errorCode);
@@ -1077,6 +1082,7 @@ namespace Icu
 			if (Methods.u_cleanup == null)
 				Methods.u_cleanup = GetMethod<MethodsContainer.u_cleanupDelegate>(IcuCommonLibHandle, "u_cleanup");
 			Methods.u_cleanup();
+			IsInitialized = false;
 		}
 
 		/// <summary>Return the ICU data directory</summary>

--- a/source/icu.net/RegexMatcher.cs
+++ b/source/icu.net/RegexMatcher.cs
@@ -10,7 +10,7 @@ namespace Icu
 	/// <summary>
 	/// Regular Expression Matcher
 	/// </summary>
-	public class RegexMatcher
+	public class RegexMatcher: IDisposable
 	{
 		/// <summary>
 		/// Constants for Regular Expression Match Modes.


### PR DESCRIPTION
This allows multi-threaded applications to initialize ICU before
starting multiple threads. The call to `Wrapper.Init()` should be the
first call of an ICU method.

See http://userguide.icu-project.org/design#TOC-ICU-Initialization-and-Termination.

+semver: minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/55)
<!-- Reviewable:end -->
