### PR TITLE
Remove dependency on `System.Runtime.InteropServices.RuntimeInformation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Remove dependency on `System.Runtime.InteropServices.RuntimeInformation` for 4.6.1
+  assembly. When running under Mono 4, `RuntimeInformation` assumes that it is running
+  on a Windows machine. This makes it useless for detecting the platform.
+
 ## [2.3.0] - 2018-02-28
 
 ### Added

--- a/source/icu.net.netstandard/icu.net.netstandard.csproj
+++ b/source/icu.net.netstandard/icu.net.netstandard.csproj
@@ -34,11 +34,11 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/icu.net/Platform.cs
+++ b/source/icu.net/Platform.cs
@@ -1,7 +1,9 @@
 // Copyright (c) 2013 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System;
+#if NETSTANDARD1_6
 using System.Runtime.InteropServices;
+#endif
 
 namespace Icu
 {
@@ -45,7 +47,7 @@ namespace Icu
 		{
 			get
 			{
-#if NET40
+#if !NETSTANDARD1_6
 				// See http://www.mono-project.com/docs/faq/technical/#how-to-detect-the-execution-platform
 				switch ((int)Environment.OSVersion.Platform)
 				{


### PR DESCRIPTION
Remove dependency on `System.Runtime.InteropServices.RuntimeInformation`
for 4.6.1 assembly. When running under Mono 4, `RuntimeInformation`
assumes that it is running on a Windows machine. This makes it useless
for detecting the platform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/66)
<!-- Reviewable:end -->
