### PR TITLE
Exposed u_getIntPropertyValue & u_hasBinaryProperty; Added UEastAsianWidth

### DIFF
--- a/source/icu.net.tests/CharacterTests.cs
+++ b/source/icu.net.tests/CharacterTests.cs
@@ -10,6 +10,37 @@ namespace Icu.Tests
 	public class CharacterTests
 	{
 		[Test]
+		public void GetIntPropertyValue()
+		{
+			// binary
+			Assert.That(Character.GetIntPropertyValue('A', Character.UProperty.DIACRITIC), Is.EqualTo(0));
+			Assert.That(Character.GetIntPropertyValue('\u02ca',Character.UProperty.DIACRITIC),
+				Is.EqualTo(1)); // MODIFIER LETTER ACUTE ACCENT
+
+			// integer
+			Assert.That((Character.UEastAsianWidth) Character.GetIntPropertyValue('A',
+				Character.UProperty.EAST_ASIAN_WIDTH),
+				Is.EqualTo(Character.UEastAsianWidth.NARROW));
+			Assert.That((Character.UEastAsianWidth) Character.GetIntPropertyValue('\u4eba',
+					Character.UProperty.EAST_ASIAN_WIDTH),
+				Is.EqualTo(Character.UEastAsianWidth.WIDE)); // CJK UNIFIED IDEOGRAPH-4EBA : rén
+
+			// mask
+			var mask =
+				Character.GetIntPropertyValue('A', Character.UProperty.GENERAL_CATEGORY_MASK);
+			Assert.That(mask & (1 << (int) Character.UCharCategory.LOWERCASE_LETTER), Is.EqualTo(0));
+			Assert.That(mask & (1 << (int) Character.UCharCategory.UPPERCASE_LETTER), Is.Not.EqualTo(0));
+
+			// invalid
+			Assert.That(
+				() => { Character.GetIntPropertyValue('A', Character.UProperty.INVALID_CODE); },
+				Throws.TypeOf<ArgumentOutOfRangeException>());
+			Assert.That(
+				() => { Character.GetIntPropertyValue('A', Character.UProperty.OTHER_PROPERTY_START); },
+				Throws.TypeOf<ArgumentOutOfRangeException>());
+		}
+
+		[Test]
 		public void Digit()
 		{
 			// valid digit tests

--- a/source/icu.net/Character.cs
+++ b/source/icu.net/Character.cs
@@ -530,6 +530,42 @@ namespace Icu
 		}
 
 		/// <summary>
+		/// East Asian Width constants.
+		/// </summary>
+		public enum UEastAsianWidth
+		{
+			/// <summary>
+			/// [N]
+			/// </summary>
+			NEUTRAL,
+			/// <summary>
+			/// [A]
+			/// </summary>
+			AMBIGUOUS,
+			/// <summary>
+			/// [H]
+			/// </summary>
+			HALFWIDTH,
+			/// <summary>
+			/// [F]
+			/// </summary>
+			FULLWIDTH,
+			/// <summary>
+			/// [Na]
+			/// </summary>
+			NARROW,
+			/// <summary>
+			/// [W]
+			/// </summary>
+			WIDE,
+			/// <summary>
+			/// One more than the highest normal <see cref="UEastAsianWidth"/> value.
+			/// </summary>
+			[Obsolete("ICU 58 The numeric value may change over time, see ICU ticket #12420.")]
+			COUNT
+		}
+
+		/// <summary>
 		/// Numeric Type constants
 		/// </summary>
 		/// <remarks>Note: UNumericType constants are parsed by preparseucd.py.
@@ -553,6 +589,45 @@ namespace Icu
 		/// when no numeric value is defined for a code point.
 		/// </summary>
 		public const double NO_NUMERIC_VALUE = (double)-123456789;
+
+		/// <summary>
+		/// Get the property value for an enumerated or integer Unicode property for a code point.
+		/// Also returns binary and mask property values.
+		/// Unicode, especially in version 3.2, defines many more properties than the original set in UnicodeData.txt.
+		/// The properties APIs are intended to reflect Unicode properties as defined in the Unicode Character Database (UCD) and Unicode Technical Reports (UTR). For details about the properties see http://www.unicode.org/ . For names of Unicode properties see the UCD file PropertyAliases.txt.
+		/// </summary>
+		/// <remarks>
+		/// If <paramref name="which"/> is <see cref="UProperty.GENERAL_CATEGORY"/>, the return value will not match
+		/// the enumeration in FwKernel: LgGeneralCharCategory.
+		/// </remarks>
+		/// <param name="characterCode">Code point to test. </param>
+		/// <param name="which">UProperty selector constant, identifies which property to check. Must be UCHAR_BINARY_START&lt;=which&lt;UCHAR_BINARY_LIMIT or UCHAR_INT_START&lt;=which&lt;UCHAR_INT_LIMIT or UCHAR_MASK_START&lt;=which&lt;UCHAR_MASK_LIMIT.</param>
+		/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="which"/> does not meet the requirement UCHAR_BINARY_START&lt;=which&lt;UCHAR_BINARY_LIMIT or UCHAR_INT_START&lt;=which&lt;UCHAR_INT_LIMIT or UCHAR_MASK_START&lt;=which&lt;UCHAR_MASK_LIMIT.</exception>
+		public static int GetIntPropertyValue(int characterCode, UProperty which)
+		{
+			if ((which < UProperty.BINARY_START || which >= UProperty.BINARY_LIMIT) &&
+			    (which < UProperty.INT_START || which >= UProperty.INT_LIMIT) &&
+			    (which < UProperty.MASK_START || which >= UProperty.MASK_LIMIT))
+				throw new ArgumentOutOfRangeException(nameof(characterCode));
+			return NativeMethods.u_getIntPropertyValue(characterCode, which);
+		}
+
+		/// <summary>
+		/// Check a binary Unicode property for a code point.
+		/// Unicode, especially in version 3.2, defines many more properties than the original set in UnicodeData.txt.
+		/// The properties APIs are intended to reflect Unicode properties as defined in the Unicode Character Database (UCD) and Unicode Technical Reports (UTR). For details about the properties see http://www.unicode.org/ucd/ . For names of Unicode properties see the UCD file PropertyAliases.txt.
+		/// Important: If ICU is built with UCD files from Unicode versions below 3.2, then properties marked with "new in Unicode 3.2" are not or not fully available.
+		/// </summary>
+		/// <param name="characterCode">Code point to test. </param>
+		/// <param name="which">UProperty selector constant, identifies which binary property to check. Must be UCHAR_BINARY_START&lt;=which&lt;UCHAR_BINARY_LIMIT. </param>
+		/// <returns>TRUE or FALSE according to the binary Unicode property value for c. Also FALSE if 'which' is out of bounds or if the Unicode version does not have data for the property at all, or not for this code point.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="which"/> does not meet the requirement UCHAR_BINARY_START&lt;=which&lt;UCHAR_BINARY_LIMIT.</exception>
+		public static bool HasBinaryProperty(int characterCode, UProperty which)
+		{
+			if (which < UProperty.BINARY_START || which >= UProperty.BINARY_LIMIT)
+				throw new ArgumentOutOfRangeException(nameof(characterCode));
+			return NativeMethods.u_hasBinaryProperty(characterCode, which);
+		}
 
 		/// <summary>
 		/// Returns the decimal digit value of the code point in the specified radix.

--- a/source/icu.net/NativeMethods.cs
+++ b/source/icu.net/NativeMethods.cs
@@ -764,6 +764,10 @@ namespace Icu
 				Character.UProperty choice);
 
 			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+			internal delegate bool u_hasBinaryPropertyDelegate(int characterCode,
+				Character.UProperty which);
+
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
 			internal delegate void u_getUnicodeVersionDelegate(out VersionInfo versionArray);
 
 			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
@@ -1086,6 +1090,7 @@ namespace Icu
 			internal u_charNameDelegate u_charName;
 			internal u_digitDelegate u_digit;
 			internal u_getIntPropertyValueDelegate u_getIntPropertyValue;
+			internal u_hasBinaryPropertyDelegate u_hasBinaryProperty;
 			internal u_getUnicodeVersionDelegate u_getUnicodeVersion;
 			internal u_getVersionDelegate u_getVersion;
 			internal u_charTypeDelegate u_charType;
@@ -1239,6 +1244,28 @@ namespace Icu
 			if (Methods.u_getIntPropertyValue == null)
 				Methods.u_getIntPropertyValue = GetMethod<MethodsContainer.u_getIntPropertyValueDelegate>(IcuCommonLibHandle, "u_getIntPropertyValue");
 			return Methods.u_getIntPropertyValue(characterCode, choice);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Check a binary Unicode property for a code point.
+		/// Unicode, especially in version 3.2, defines many more properties than the original set in UnicodeData.txt.
+		/// The properties APIs are intended to reflect Unicode properties as defined in the Unicode Character Database (UCD) and Unicode Technical Reports (UTR). For details about the properties see http://www.unicode.org/ucd/ . For names of Unicode properties see the UCD file PropertyAliases.txt.
+		/// Important: If ICU is built with UCD files from Unicode versions below 3.2, then properties marked with "new in Unicode 3.2" are not or not fully available.
+		/// </summary>
+		/// <param name="characterCode">Code point to test. </param>
+		/// <param name="choice">UProperty selector constant, identifies which binary property to check. Must be UCHAR_BINARY_START&lt;=which&lt;UCHAR_BINARY_LIMIT. </param>
+		/// <returns>TRUE or FALSE according to the binary Unicode property value for c. Also FALSE if 'which' is out of bounds or if the Unicode version does not have data for the property at all, or not for this code point.</returns>
+		/// ------------------------------------------------------------------------------------
+		public static bool u_hasBinaryProperty(
+			int characterCode,
+			Character.UProperty choice)
+		{
+			if (Methods.u_hasBinaryProperty == null)
+				Methods.u_hasBinaryProperty =
+					GetMethod<MethodsContainer.u_hasBinaryPropertyDelegate>(
+						IcuCommonLibHandle, "u_hasBinaryProperty");
+			return Methods.u_hasBinaryProperty(characterCode, choice);
 		}
 
 		public static void u_getUnicodeVersion(out VersionInfo versionArray)


### PR DESCRIPTION
## Why am I exposing the two methods

Yes, I have read the `<remarks>` documentation tag on `u_getIntPropertyValue`.

> This not only makes it easier to use

But this implementation is seriously incomplete. I failed to take "no usable interface at all" as "easier to use".

> but more importantly it prevents accidental use of the UCHAR_GENERAL_CATEGORY, which returns an enumeration that doesn't match the enumeration in FwKernel: LgGeneralCharCategory

(Google didn't tell me what is `FwKernel` or `LgGeneralCharCategory`. Pardon my naive assertions...)

It's up to the user to make a legitimate API call. If the original icu4c (and many other wrappers like [Android](https://developer.android.com/reference/android/icu/lang/UCharacter.html#getIntPropertyValue(int,%20int))) exposed it, why should this middleware hide it?

Plus, the wrapped `GetIntPropertyValue` can simply throw an exception when UCHAR_GENERAL_CATEGORY is passed, in case it will cause a critical issue.

## Tests

`icu.net | icu.net.tests | BreakIteratorTests_Chinese <.NETCoreApp-v2.1> | CanIterateBackwards` somehow failed on my machine with

```
  Expected is <System.Int32[12]>, actual is <System.Int32[18]>
  Values differ at index [1]
  Expected: 2
  But was:  1

   at Icu.Tests.BreakIteratorTests_Chinese.CanIterateBackwards() in icu-dotnet\source\icu.net.tests\BreakIteratorTests.Chinese.cs:line 294
```
not sure if my changes broke it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/69)
<!-- Reviewable:end -->
