### PR TITLE
Fix targeting platform (#70)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,7 @@ indent_style = tab
 tab_width = 4
 
 # Settings Visual Studio uses for the generated files
-[*.{csproj,resx,settings,vcxproj*,vdproj,xml}]
+[*.{csproj,resx,settings,vcxproj*,vdproj,xml,yml}]
 indent_style = space
 indent_size = 2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.3.4] - 2018-08-27
+
+### Known bug
+
+- icu.net.dll for netstandard1.6 has the wrong version number (always 1.0.0) (#72)
+
+### Fixed
+
+- Change PlatformTarget to AnyCPU (issue #70). The wrong x86 target sneaked in
+  with the changes for version 2.3.3.
+
 ## [2.3.3] - 2018-07-03
 
 ### Changed

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,6 +3,14 @@ branches:
   master:
     tag: beta
     regex: (origin/)?master
+  hotfix:
+    tag: beta
+    regex: (origin/)?hotfix[/-]
+    increment: Patch
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: false
+    tracks-release-branches: false
+    is-release-branch: false
   pull-request:
     mode: ContinuousDeployment
     tag: PR

--- a/source/TestHelper/TestHelper.csproj
+++ b/source/TestHelper/TestHelper.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>Icu.Tests</RootNamespace>
     <AssemblyName>TestHelper</AssemblyName>
     <IsPackable>false</IsPackable>
-    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\icu.net\icu.net.csproj" />

--- a/source/icu.net.tests/icu.net.tests.csproj
+++ b/source/icu.net.tests/icu.net.tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>Icu.Tests</RootNamespace>
@@ -10,7 +10,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <IsPackable>false</IsPackable>
-    <PlatformTarget Condition="'$(TargetFramework)'=='net461'">x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Icu4c.Win.Full.Lib" Version="62.1.4-beta" />

--- a/source/icu.net/icu.net.csproj
+++ b/source/icu.net/icu.net.csproj
@@ -29,7 +29,6 @@ NOTE: this package contains the managed wrapper part of icu.net. You'll also hav
   <!-- Full .NET Framework properties -->
   <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard1.6'">
     <DefineConstants>$(DefineConstants);FEATURE_ICLONEABLE</DefineConstants>
-    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <!-- Using Mono msbuild with .NET Core build targets does not support
   assembly signing, yet. -->


### PR DESCRIPTION
The PlatformTarget should be AnyCPU as it used to be until 2.3.2.
This allows it to run in both 32- and 64-bit processes. Somehow
the x86 target sneaked in for 2.3.3. This fixes issue #70.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/75)
<!-- Reviewable:end -->
