### PR TITLE
Use slightly more compact format for version number

### DIFF
--- a/source/icu.net/icu.net.csproj
+++ b/source/icu.net/icu.net.csproj
@@ -59,6 +59,6 @@ NOTE: this package contains the managed wrapper part of icu.net. You'll also hav
   </ItemGroup>
   <Target Name="StoreVersion" AfterTargets="Build">
     <MakeDir Directories="$(OutputPath)"/>
-    <WriteLinesToFile File="$(OutputPath)/version.txt" Lines="$(GitVersion_NuGetVersion)" Overwrite="True" />
+    <WriteLinesToFile File="$(OutputPath)/version.txt" Lines="$(GitVersion_FullSemVer)" Overwrite="True" />
   </Target>
 </Project>


### PR DESCRIPTION
This will set the build number on Jenkins to `2.4.0-beta.14-75` instead of `2.4.0-beta0014-75`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/78)
<!-- Reviewable:end -->
