### PR TITLE
Fix version number for netstandard1.6 (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Change PlatformTarget to AnyCPU (issue #70). The wrong x86 target sneaked in
   with the changes for version 2.3.3.
+- Fix version number of netstandard1.6 icu.net assembly (issue #72) so that it
+  matches the version number of the nuget package.
 
 ## [2.3.3] - 2018-07-03
 

--- a/source/icu.net/icu.net.csproj
+++ b/source/icu.net/icu.net.csproj
@@ -43,16 +43,13 @@ NOTE: this package contains the managed wrapper part of icu.net. You'll also hav
   <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
   </ItemGroup>
-  <ItemGroup Condition="!$(TargetFramework.Contains('netstandard'))">
-    <!-- still missing GitVersionTask for netstandard! -->
-    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.6'">
     <Compile Remove="SortKey.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0014">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="SIL.ReleaseTasks" Version="2.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This change updates GitVersionTask to the latest beta which adds support
for NetStandard. Unfortunately due to a bug in GitVersionTask this will
only successfully build on the command line, not in VS or Rider.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/79)
<!-- Reviewable:end -->
