### PR TITLE
Fix crash if filename contains minor version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.4.0] - 2018-10-24
+
 ### Known bug
 
 - icu.net.dll for netstandard1.6 has the wrong version number (always 1.0.0) (#72)
+
+### Fixed
+
+- Fix crash if filename contains minor version number, e.g. `libicuuc.so.60.1`
 
 ### Changed
 

--- a/source/icu.net.tests/NativeMethodsHelperTests.cs
+++ b/source/icu.net.tests/NativeMethodsHelperTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2018 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System.IO;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Icu.Tests
+{
+#if !NET40
+	[TestFixture]
+	public class NativeMethodsHelperTests
+	{
+		private string _filenameWindows;
+		private string _filenameLinux;
+
+		private int CallGetIcuVersionInfoForNetCoreOrWindows()
+		{
+			var icunetAssembly = typeof(Wrapper).Assembly;
+			var nativeMethodsHelperType = icunetAssembly.GetType("Icu.NativeMethodsHelper");
+			var method = nativeMethodsHelperType.GetMethod("GetIcuVersionInfoForNetCoreOrWindows",
+				BindingFlags.Static | BindingFlags.Public);
+			var result = method?.Invoke(null, null);
+			var icuVersionInfoType = icunetAssembly.GetType("Icu.IcuVersionInfo");
+			var icuVersionFieldInfo = icuVersionInfoType.GetField("IcuVersion");
+			return (int) icuVersionFieldInfo.GetValue(result);
+		}
+
+		[SetUp]
+		public void Setup()
+		{
+			// Trying to get the ICU version checks for filename, so we create a dummy file with
+			// a version number.
+			_filenameWindows = Path.Combine(NativeMethodsTests.OutputDirectory,"icuuc99.1.dll");
+			File.WriteAllText(_filenameWindows, "just a dummy file");
+			_filenameLinux = Path.Combine(NativeMethodsTests.OutputDirectory,"libicuuc.so.99.1");
+			File.WriteAllText(_filenameLinux, "just a dummy file");
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			File.Delete(_filenameWindows);
+			File.Delete(_filenameLinux);
+			Wrapper.Cleanup();
+		}
+
+		[Test]
+		public void GetIcuVersionInfoForNetCoreOrWindows_DoesNotCrash()
+		{
+			Wrapper.Cleanup();
+			var result = CallGetIcuVersionInfoForNetCoreOrWindows();
+			Assert.That(result, Is.EqualTo(99));
+		}
+	}
+#endif
+}

--- a/source/icu.net.tests/NativeMethodsTests.cs
+++ b/source/icu.net.tests/NativeMethodsTests.cs
@@ -37,7 +37,7 @@ namespace Icu.Tests
 			return $"{prefix}{archSubdir}";
 		}
 
-		private static string OutputDirectory => Path.GetDirectoryName(
+		internal static string OutputDirectory => Path.GetDirectoryName(
 			new Uri(
 #if NET40
 				typeof(NativeMethodsTests).Assembly.CodeBase

--- a/source/icu.net/NativeMethods.cs
+++ b/source/icu.net/NativeMethods.cs
@@ -295,7 +295,15 @@ namespace Icu
 		{
 			lock (_lock)
 			{
-				u_cleanup();
+				try
+				{
+					u_cleanup();
+				}
+				catch
+				{
+					// ignore failures - can happen when running unit tests
+				}
+
 				if (IsWindows)
 				{
 					if (_IcuCommonLibHandle != IntPtr.Zero)
@@ -324,6 +332,7 @@ namespace Icu
 			_IcuPath = null;
 
 #if !NET40
+			NativeMethodsHelper.Reset();
 			var icuInfo = NativeMethodsHelper.GetIcuVersionInfoForNetCoreOrWindows();
 
 			if (icuInfo.Success)


### PR DESCRIPTION
Previously icu.net crashed if the filename on Linux contained a
minor version number, e.g. `libicuuc.so.60.1`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/85)
<!-- Reviewable:end -->
