### PR TITLE
Added support for nfkc_cf normalizer

### DIFF
--- a/source/icu.net.tests/NormalizerTests.cs
+++ b/source/icu.net.tests/NormalizerTests.cs
@@ -15,6 +15,9 @@ namespace Icu.Tests
 		[TestCase("tést", Normalizer.UNormalizationMode.UNORM_NFD, ExpectedResult = "te\u0301st")]
 		[TestCase("te\u0301st", Normalizer.UNormalizationMode.UNORM_NFC, ExpectedResult = "tést")]
 		[TestCase("te\u0301st", Normalizer.UNormalizationMode.UNORM_NFD, ExpectedResult = "te\u0301st")]
+		[TestCase("Te\u0301st", Normalizer.UNormalizationMode.UNORM_NFKC, ExpectedResult = "Tést")]
+        [TestCase("Te\u0301st", Normalizer.UNormalizationMode.UNORM_NFKC_CF, ExpectedResult = "tést")]
+
 		public string Normalize(string src, Normalizer.UNormalizationMode mode)
 		{
 			return Normalizer.Normalize(src, mode);

--- a/source/icu.net/Normalizer.cs
+++ b/source/icu.net/Normalizer.cs
@@ -28,7 +28,10 @@ namespace Icu
 			///<summary>Compatibility decomposition followed by canonical composition.</summary>
 			UNORM_NFKC = 5,
 			/// <summary>"Fast C or D" form.</summary>
-			UNORM_FCD = 6
+			UNORM_FCD = 6,
+			/// NFKC followed by case folding
+			UNORM_NFKC_CF = 7
+
 		}
 
 		internal enum UNormalization2Mode
@@ -43,8 +46,8 @@ namespace Icu
 		{
 			ErrorCode errorCode;
 			var ret = NativeMethods.unorm2_getInstance(IntPtr.Zero,
-				(mode == UNormalizationMode.UNORM_NFC || mode == UNormalizationMode.UNORM_NFD) ? "nfc" : "nfkc",
-				(mode == UNormalizationMode.UNORM_NFC || mode == UNormalizationMode.UNORM_NFKC) ?
+				(mode == UNormalizationMode.UNORM_NFC || mode == UNormalizationMode.UNORM_NFD) ? "nfc" : (mode == UNormalizationMode.UNORM_NFKC_CF ? "nfkc_cf" : "nfkc"),
+				(mode == UNormalizationMode.UNORM_NFC || mode == UNormalizationMode.UNORM_NFKC || mode == UNormalizationMode.UNORM_NFKC_CF) ?
 					UNormalization2Mode.UNORM2_COMPOSE : UNormalization2Mode.UNORM2_DECOMPOSE,
 				out errorCode);
 			if (errorCode != ErrorCode.NoErrors)


### PR DESCRIPTION
I added the missing support for the "nfkc_cf" normalizer and a couple of tests to cover it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/87)
<!-- Reviewable:end -->
