### PR TITLE
Allow to confine version number after initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - add BreakIterator.GetEnumerator() method and BreakEnumerator class to allow
   enumerating over word segments as described in the ICU user guide (the
   existing method BreakIterator.Split ignores spaces and punctuation)
+- Wrapper.MinSupportedIcuVersion and Wrapper.MaxSupportedIcuVersion constants
 
 ### Changed
 
 - output error on Linux if unmanaged libraries can't be loaded
+- allow to confine version number after initialization. In this case we internally
+  do a reset and re-initialize with the new version number.
 
 ## [2.4.0] - 2018-10-24
 

--- a/source/icu.net.tests/IcuWrapperTests.cs
+++ b/source/icu.net.tests/IcuWrapperTests.cs
@@ -1,5 +1,7 @@
 // Copyright (c) 2013 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+
+using System;
 using NUnit.Framework;
 
 namespace Icu.Tests
@@ -7,14 +9,19 @@ namespace Icu.Tests
 	[TestFixture]
 	public class IcuWrapperTests
 	{
+		[TearDown]
+		public void TearDown()
+		{
+			Wrapper.ConfineIcuVersions(Wrapper.MinSupportedIcuVersion, Wrapper.MaxSupportedIcuVersion);
+		}
+
 		[Test]
 		public void UnicodeVersion()
 		{
 			string result = Wrapper.UnicodeVersion;
 			Assert.That(result.Length, Is.GreaterThanOrEqualTo(3));
 			Assert.That(result.IndexOf("."), Is.GreaterThan(0));
-			int major;
-			Assert.That(int.TryParse(result.Substring(0, result.IndexOf(".")), out major), Is.True);
+			Assert.That(int.TryParse(result.Substring(0, result.IndexOf(".")), out var major), Is.True);
 		}
 
 		[Test]
@@ -23,8 +30,23 @@ namespace Icu.Tests
 			string result = Wrapper.IcuVersion;
 			Assert.That(result.Length, Is.GreaterThanOrEqualTo(4));
 			Assert.That(result.IndexOf("."), Is.GreaterThan(0));
-			int major;
-			Assert.That(int.TryParse(result.Substring(0, result.IndexOf(".")), out major), Is.True);
+			Assert.That(int.TryParse(result.Substring(0, result.IndexOf(".")), out var major), Is.True);
+		}
+
+#if NETCOREAPP2_1
+		[Ignore("Platform is not supported in NUnit for .NET Core 2")]
+#else
+		[Platform(Exclude = "Linux",
+			Reason = "These tests require ICU4C installed from NuGet packages which isn't available on Linux")]
+#endif
+		[Test]
+		public void ConfineVersions_WorksAfterInit()
+		{
+			Wrapper.Init();
+			var version = int.Parse(NativeMethodsTests.MinIcuLibraryVersionMajor);
+			Wrapper.ConfineIcuVersions(version);
+
+			Assert.That(Wrapper.IcuVersion, Is.EqualTo(NativeMethodsTests.MinIcuLibraryVersion));
 		}
 	}
 }

--- a/source/icu.net.tests/NativeMethodsHelperTests.cs
+++ b/source/icu.net.tests/NativeMethodsHelperTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2018 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
+using System;
 using System.IO;
 using System.Reflection;
 using NUnit.Framework;
@@ -31,9 +32,9 @@ namespace Icu.Tests
 		{
 			// Trying to get the ICU version checks for filename, so we create a dummy file with
 			// a version number.
-			_filenameWindows = Path.Combine(NativeMethodsTests.OutputDirectory,"icuuc99.1.dll");
+			_filenameWindows = Path.Combine(NativeMethodsTests.OutputDirectory, $"icuuc{Wrapper.MaxSupportedIcuVersion}.dll");
 			File.WriteAllText(_filenameWindows, "just a dummy file");
-			_filenameLinux = Path.Combine(NativeMethodsTests.OutputDirectory,"libicuuc.so.99.1");
+			_filenameLinux = Path.Combine(NativeMethodsTests.OutputDirectory, $"libicuuc.so.{Wrapper.MaxSupportedIcuVersion}.1");
 			File.WriteAllText(_filenameLinux, "just a dummy file");
 		}
 
@@ -50,7 +51,7 @@ namespace Icu.Tests
 		{
 			Wrapper.Cleanup();
 			var result = CallGetIcuVersionInfoForNetCoreOrWindows();
-			Assert.That(result, Is.EqualTo(99));
+			Assert.That(result, Is.EqualTo(Wrapper.MaxSupportedIcuVersion));
 		}
 	}
 #endif

--- a/source/icu.net.tests/NativeMethodsTests.cs
+++ b/source/icu.net.tests/NativeMethodsTests.cs
@@ -19,9 +19,9 @@ namespace Icu.Tests
 	{
 		private string _tmpDir;
 		private string _pathEnvironmentVariable;
-		private const string FullIcuLibraryVersion = "62.1";
-		private const string MinIcuLibraryVersion = "59.1";
-		private const string MinIcuLibraryVersionMajor = "59";
+		public const string FullIcuLibraryVersion = "62.1";
+		public const string MinIcuLibraryVersion = "59.1";
+		public const string MinIcuLibraryVersionMajor = "59";
 
 		private static void CopyFile(string srcPath, string dstDir)
 		{

--- a/source/icu.net/IcuWrapper.cs
+++ b/source/icu.net/IcuWrapper.cs
@@ -11,6 +11,9 @@ namespace Icu
 	/// </summary>
 	public static class Wrapper
 	{
+		public const int MinSupportedIcuVersion = 44;
+		public const int MaxSupportedIcuVersion = 70;
+
 		#region Public Properties
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -73,8 +76,7 @@ namespace Icu
 		/// ------------------------------------------------------------------------------------
 		public static ErrorCode Init()
 		{
-			ErrorCode errorCode;
-			NativeMethods.u_init(out errorCode);
+			NativeMethods.u_init(out var errorCode);
 			return errorCode;
 		}
 

--- a/source/icu.net/NativeMethods/NativeMethodsHelper.cs
+++ b/source/icu.net/NativeMethods/NativeMethodsHelper.cs
@@ -120,10 +120,9 @@ namespace Icu
 		private static bool TryGetPathFromAssemblyDirectory()
 		{
 			var assemblyDirectory = new DirectoryInfo(NativeMethods.DirectoryOfThisAssembly);
-			int version;
 
 			// 1. Check in {assemblyDirectory}/
-			if (TryGetIcuVersionNumber(assemblyDirectory, out version))
+			if (TryGetIcuVersionNumber(assemblyDirectory, out var version))
 			{
 				IcuVersion = new IcuVersionInfo(assemblyDirectory, version);
 				return true;
@@ -179,8 +178,12 @@ namespace Icu
 				.Select(x =>
 				{
 					var match = IcuBinaryRegex.Match(x.Name);
-					if (match.Success && int.TryParse(match.Groups["version"].Value, out var retVal))
+					if (match.Success &&
+						int.TryParse(match.Groups["version"].Value, out var retVal) &&
+						retVal >= NativeMethods.MinIcuVersion && retVal <= NativeMethods.MaxIcuVersion)
+					{
 						return retVal;
+					}
 
 					return new int?();
 				})


### PR DESCRIPTION
Also add Wrapper.MinSupportedIcuVersion and
Wrapper.MaxSupportedIcuVersion constants.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/94)
<!-- Reviewable:end -->
