### PR TITLE
Fixed the text in memory between calls to unmanaged ICU

### DIFF
--- a/source/icu.net/icu.net.csproj
+++ b/source/icu.net/icu.net.csproj
@@ -39,6 +39,9 @@ See full changelog at https://github.com/sillsdev/icu-dotnet/blob/master/CHANGEL
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>icu.net.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <PropertyGroup >
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />


### PR DESCRIPTION
Fixed the text in memory between calls to unmanaged ICU. Also fixed a logic problem in SetText()

This fixes two problems:
* [Issue #81](https://github.com/sillsdev/icu-dotnet/issues/81)
* A logic problem where _breakIterator.ubrk_setText() wasn't being called if _breakIterator == IntPtr.Zero when the method was entered. The method was just calling InitializeBreakIterator() but not ubrk_setText()