### PR TITLE
Remove double call of dispose when disposing `RuleBasedCollator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- remove double call of dispose when disposing `RuleBasedCollator`
+
 ## [2.5.2] - 2018-12-10
 
 ### Changed

--- a/source/icu.net/Collation/RuleBasedCollator.cs
+++ b/source/icu.net/Collation/RuleBasedCollator.cs
@@ -60,12 +60,6 @@ namespace Icu.Collation
 			{
 				get { return handle == IntPtr.Zero; }
 			}
-
-			protected override void Dispose(bool disposing)
-			{
-				base.Dispose(disposing);
-				ReleaseHandle();
-			}
 		}
 
 		private bool _disposingValue = false; // To detect redundant calls


### PR DESCRIPTION
The `SafeHandle` base class calls `ReleaseHandle()`, so there is
no need to override `Dispose(bool)` and call it again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/104)
<!-- Reviewable:end -->
