### PR TITLE
Fix for #127 BreakIterator.GetBoundaries is exponentially slow depending on the size of the source text

### DIFF
--- a/source/icu.net/BreakIterators/RuleBasedBreakIterator.cs
+++ b/source/icu.net/BreakIterators/RuleBasedBreakIterator.cs
@@ -155,7 +155,7 @@ namespace Icu
 
 			// If the next index is going to move this out of boundaries, do
 			// not incremement the index.
-			if (nextIndex >= Boundaries.Length)
+			if (nextIndex >= _textBoundaries.Length)
 			{
 				return DONE;
 			}
@@ -196,7 +196,7 @@ namespace Icu
 				return 0;
 			}
 
-			_currentIndex = Boundaries.Length - 1;
+			_currentIndex = _textBoundaries.Length - 1;
 			return _textBoundaries[_currentIndex].Offset;
 		}
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/128)
<!-- Reviewable:end -->
