### PR TITLE
Add Icu.Wrapper.Verbose property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add build number to AssemblyFileVersion
 - Add basic non-static `Transliterator` class with transliterate functionality (tylerpayne)
+- Add `Icu.Wrapper.Verbose` property to assist in diagnosing load problems
 
 ### Fixed
 

--- a/source/icu.net/IcuWrapper.cs
+++ b/source/icu.net/IcuWrapper.cs
@@ -44,6 +44,15 @@ namespace Icu
 				return arg.ToString();
 			}
 		}
+
+		/// <summary>
+		/// Set to <c>true</c> to output diagnostic trace messages
+		/// </summary>
+		public static bool Verbose
+		{
+			get => NativeMethods.Verbose;
+			set => NativeMethods.Verbose = value;
+		}
 		#endregion
 
 		/// ------------------------------------------------------------------------------------


### PR DESCRIPTION
Setting Icu.Wrapper.Verbose to `true` outputs additional information that might help in diagnosing loading the unmanaged icu library.

+semver:minor