### PR TITLE
Fix return type of GetCombiningClass

### DIFF
--- a/source/Directory.Build.targets
+++ b/source/Directory.Build.targets
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="CopyPackage" AfterTargets="Pack" Condition="'$(LOCAL_NUGET_REPO)'!='' AND '$(IsPackable)'=='true'">
+    <Copy SourceFiles="$(PackageOutputPath)/$(PackageId).$(PackageVersion).nupkg"
+      DestinationFolder="$(LOCAL_NUGET_REPO)"/>
+  </Target>
+</Project>

--- a/source/icu.net.tests/Normalization/Normalizer2Tests.cs
+++ b/source/icu.net.tests/Normalization/Normalizer2Tests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 SIL International
+// Copyright (c) 2018-2021 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using Icu.Normalization;
@@ -41,6 +41,14 @@ namespace Icu.Tests
 		{
 			var normalizer = Normalizer2.GetInstance(null, "nfc", mode);
 			return normalizer.IsNormalized(str);
+		}
+
+		[TestCase('a', ExpectedResult = 0)]
+		[TestCase(769, ExpectedResult = 0xE6)]
+		public int GetCombiningClass(int characterCode)
+		{
+			var normalizer = Normalizer2.GetInstance(null, "nfc", Normalizer2.Mode.COMPOSE);
+			return normalizer.GetCombiningClass(characterCode);
 		}
 	}
 }

--- a/source/icu.net/Normalization/Normalizer2.cs
+++ b/source/icu.net/Normalization/Normalizer2.cs
@@ -1,9 +1,7 @@
-// // Copyright (c) 2018 SIL International
-// // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+// Copyright (c) 2018-2021 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
-using System.Runtime.InteropServices;
-using Icu;
 
 namespace Icu.Normalization
 {
@@ -210,7 +208,7 @@ namespace Icu.Normalization
 		/// <returns>c's combining class</returns>
 		public int GetCombiningClass(int c)
 		{
-			return NativeMethods.unorm2_getCombiningClass(_Normalizer, c);
+			return (byte)NativeMethods.unorm2_getCombiningClass(_Normalizer, c);
 		}
 
 		/// <summary>

--- a/source/icu.net/Normalization/Normalizer2.cs
+++ b/source/icu.net/Normalization/Normalizer2.cs
@@ -206,7 +206,7 @@ namespace Icu.Normalization
 		/// </summary>
 		/// <param name="c">code point</param>
 		/// <returns>c's combining class</returns>
-		public int GetCombiningClass(int c)
+		public byte GetCombiningClass(int c)
 		{
 			return (byte)NativeMethods.unorm2_getCombiningClass(_Normalizer, c);
 		}


### PR DESCRIPTION
Cast the return type to byte to match the C++ API.
This prevents corrupting the return value with leading bits.

Fixes #139 and https://jira.sil.org/browse/LT-20408

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/icu-dotnet/140)
<!-- Reviewable:end -->
