### PR TITLE
Fix appveyor environment setting

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ branches:
   - master
 image: Visual Studio 2019
 init:
-  - cmd: >-
+  - cmd: |
       set GITVERSION_BUILD_NUMBER=%APPVEYOR_BUILD_NUMBER%
       set GitVersion_NoNormalizeEnabled=true
       set IGNORE_NORMALISATION_GIT_HEAD_MOVE=1


### PR DESCRIPTION
The `cmd: >-` concatenates lines if there are no empty lines in-between, so this change should fix this.