### PR TITLE
Fix construction of local with language and keywords

### DIFF
--- a/source/icu.net.tests/LocaleTests.cs
+++ b/source/icu.net.tests/LocaleTests.cs
@@ -180,6 +180,17 @@ namespace Icu.Tests
 		}
 
 		[Test]
+		public void ConstructFromLanguageAndKeywords_ScriptAndKeywords()
+		{
+			Locale locale = new Locale("sr", string.Empty, string.Empty, "currency=USD");
+			Assert.That(locale.Id, Is.EqualTo("sr@currency=USD"));
+			Assert.That(locale.Language, Is.EqualTo("sr"));
+			Assert.That(locale.Script, Is.Empty);
+			Assert.That(locale.Country, Is.Empty);
+			Assert.That(locale.Variant, Is.Empty);
+		}
+
+		[Test]
 		public void ToString_SameAsId()
 		{
 			Locale locale = new Locale("en-US");

--- a/source/icu.net/Locale.cs
+++ b/source/icu.net/Locale.cs
@@ -64,8 +64,11 @@ namespace Icu
 		/// <param name="keywordsAndValues">A string consisting of keyword/values pairs, such as "collation=phonebook;currency=euro"</param>
 		public Locale(string language, string country, string variant, string keywordsAndValues)
 		{
-			var bldr = new StringBuilder();
-			bldr.AppendFormat("{0}_{1}", language, country);
+			var bldr = new StringBuilder(language);
+			if (!string.IsNullOrEmpty(country) || !string.IsNullOrEmpty(variant))
+			{
+				bldr.AppendFormat("_{0}", country);
+			}
 			if (!string.IsNullOrEmpty(variant))
 			{
 				bldr.AppendFormat("_{0}", variant);


### PR DESCRIPTION
Construction of a locale with only language and keywords is currently broken:

```
var loc = new Locale("de", null, null, "lb=loose");
```
The `loc.Id` returned `de__@LB=LOOSE`, which is wrong and not accepted by ICU. It must be `de@lb=loose`