### PR TITLE
Fix passing locale to ubrk_open

### DIFF
--- a/source/icu.net.tests/BreakIteratorTests.cs
+++ b/source/icu.net.tests/BreakIteratorTests.cs
@@ -59,6 +59,17 @@ namespace Icu.Tests
 		}
 
 		[Test]
+		public void GetBoundaries_LocaleDependentBreakPoints_Line()
+		{
+			var text = "論‼";
+
+			var parts = BreakIterator.GetBoundaries(BreakIterator.UBreakIteratorType.LINE, new Locale("ja@lb=loose"), text);
+
+			// we only get 2 boundaries if the ja locale is passed correctly
+			Assert.That(parts.Count(), Is.EqualTo(2));
+		}
+
+		[Test]
 		public void GetBoundaries_Sentence()
 		{
 			var text = "Aa bb. Ccdef 3.5 x? Y?x! Z";

--- a/source/icu.net/NativeMethods/NativeMethods_BreakIterator.cs
+++ b/source/icu.net/NativeMethods/NativeMethods_BreakIterator.cs
@@ -12,7 +12,7 @@ namespace Icu
 		{
 			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
 			internal delegate IntPtr ubrk_openDelegate(BreakIterator.UBreakIteratorType type,
-				string locale, string text, int textLength, out ErrorCode errorCode);
+				[MarshalAs(UnmanagedType.LPStr)] string locale, string text, int textLength, out ErrorCode errorCode);
 
 			[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
 			internal delegate IntPtr ubrk_openRulesDelegate(string rules, int rulesLength,


### PR DESCRIPTION
The locale string must be passed as UnmanagedType.LPStr, as opposed to the actual text, which must be passed as Unicode string.
Otherwise, only the first character of the locale string is used.

An example, for which the locale actually matters, is added as test.