### PR TITLE
Only require System.ValueTuple v4.4

### DIFF
--- a/source/icu.net/icu.net.csproj
+++ b/source/icu.net/icu.net.csproj
@@ -16,7 +16,7 @@ NOTE: this package contains the managed wrapper part of icu.net. You'll also hav
     <PackageReference Include="GitVersion.MsBuild" Version="5.8.1" PrivateAssets="all" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" PrivateAssets="all" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="all" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />


### PR DESCRIPTION
As opposed to 4.5, which causes a versioning conflict in repos like FLExBridge. The projects there that target .NET Standard 2.0 also reference v4.4, resulting in a small but ugly warning.