### PR TITLE
LT-21010: ToCharacters() fix bug with upper Unicode planes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- ToCharacters() fix bug with upper Unicode planes
+
 ## [2.8.0] - 2022-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-- ToCharacters() fix bug with upper Unicode planes
+
+- Fix bug in `UnicodeSet.ToCharacters()`with upper Unicode planes (LT-21010)
 
 ## [2.8.0] - 2022-06-24
 

--- a/source/icu.net.tests/UnicodeSetTests.cs
+++ b/source/icu.net.tests/UnicodeSetTests.cs
@@ -52,5 +52,14 @@ namespace Icu.Tests
 		{
 			Assert.That(() => UnicodeSet.ToCharacters("[A-"), Throws.ArgumentException);
 		}
+
+		[Test]
+		public void ToCharacters_UpperPlane()
+		{
+			string pattern = @"[\U00010D00]";
+			string strForUpperPlaneCharacter = UnicodeSet.ToCharacters(pattern).First();
+			Assert.That(strForUpperPlaneCharacter, Is.EqualTo("𐴀"));
+			Assert.That(char.ConvertToUtf32(strForUpperPlaneCharacter, 0), Is.EqualTo(0x00010D00));
+		}
 	}
 }

--- a/source/icu.net/UnicodeSet.cs
+++ b/source/icu.net/UnicodeSet.cs
@@ -82,7 +82,7 @@ namespace Icu
 						// Add a character range to the set
 						for (var j = startChar; j <= endChar; j++)
 						{
-							output.Add(string.Format(CultureInfo.InvariantCulture, "{0}", (char)j));
+								output.Add(char.ConvertFromUtf32(j));
 						}
 					}
 					else

--- a/source/icu.net/UnicodeSet.cs
+++ b/source/icu.net/UnicodeSet.cs
@@ -82,7 +82,7 @@ namespace Icu
 						// Add a character range to the set
 						for (var j = startChar; j <= endChar; j++)
 						{
-								output.Add(char.ConvertFromUtf32(j));
+							output.Add(char.ConvertFromUtf32(j));
 						}
 					}
 					else


### PR DESCRIPTION
We were casting the Unicode code point into a char. Now we
use char.ConvertFromUtf32().
https://jira.sil.org/browse/LT-21010
