### PR TITLE
Don't call any ICU methods after calling `u_cleanup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support .net 6.0
 
+### Fixed
+
+- Fixed crash in `Wrapper.Cleanup` (#176)
+
 ## [2.8.1] - 2022-07-08
 
 ### Fixed

--- a/source/icu.net.tests/IcuWrapperTests.cs
+++ b/source/icu.net.tests/IcuWrapperTests.cs
@@ -87,8 +87,8 @@ namespace Icu.Tests
 		{
 			var result = Wrapper.IcuVersion;
 			Assert.That(result.Length, Is.GreaterThanOrEqualTo(4));
-			Assert.That(result.IndexOf("."), Is.GreaterThan(0));
-			Assert.That(int.TryParse(result.Substring(0, result.IndexOf(".")), out var major), Is.True);
+			Assert.That(result.IndexOf(".", StringComparison.Ordinal), Is.GreaterThan(0));
+			Assert.That(int.TryParse(result.Substring(0, result.IndexOf(".", StringComparison.Ordinal)), out var major), Is.True);
 		}
 
 		[Platform(Exclude = "Linux",

--- a/source/icu.net/IcuWrapper.cs
+++ b/source/icu.net/IcuWrapper.cs
@@ -116,6 +116,8 @@ namespace Icu
 		/// Cleans up the ICU files that could be locked. This should be the last ICU method
 		/// that gets called.
 		/// </summary>
+		/// <remarks>This method is not thread-safe! All other threads should stop using ICU
+		/// before calling this function. </remarks>
 		/// <seealso href="http://userguide.icu-project.org/design#TOC-ICU-Initialization-and-Termination"/>
 		/// ------------------------------------------------------------------------------------
 		[PublicAPI]

--- a/source/icu.net/NativeMethods/NativeMethods.cs
+++ b/source/icu.net/NativeMethods/NativeMethods.cs
@@ -358,6 +358,20 @@ namespace Icu
 			Trace.WriteLineIf(Verbose, "icu.net: Cleanup");
 			lock (_lock)
 			{
+				Methods = new MethodsContainer();
+				BiDiMethods = new BiDiMethodsContainer();
+				BreakIteratorMethods = new BreakIteratorMethodsContainer();
+				CodepageConversionMethods = new CodepageConversionMethodsContainer();
+				CollatorMethods = new CollatorMethodsContainer();
+				LocalesMethods = new LocalesMethodsContainer();
+				MessageFormatMethods = new MessageFormatMethodsContainer();
+				NormalizeMethods = new NormalizeMethodsContainer();
+				RegexMethods = new RegexMethodsContainer();
+				ResourceBundleMethods = new ResourceBundleMethodsContainer();
+				TransliteratorMethods = new TransliteratorMethodsContainer();
+				UnicodeSetMethods = new UnicodeSetMethodsContainer();
+				ResetIcuVersionInfo();
+
 				try
 				{
 					u_cleanup();
@@ -383,20 +397,6 @@ namespace Icu
 				}
 				_IcuCommonLibHandle = IntPtr.Zero;
 				_IcuI18NLibHandle = IntPtr.Zero;
-
-				Methods = new MethodsContainer();
-				BiDiMethods = new BiDiMethodsContainer();
-				BreakIteratorMethods = new BreakIteratorMethodsContainer();
-				CodepageConversionMethods = new CodepageConversionMethodsContainer();
-				CollatorMethods = new CollatorMethodsContainer();
-				LocalesMethods = new LocalesMethodsContainer();
-				MessageFormatMethods = new MessageFormatMethodsContainer();
-				NormalizeMethods = new NormalizeMethodsContainer();
-				RegexMethods = new RegexMethodsContainer();
-				ResourceBundleMethods = new ResourceBundleMethodsContainer();
-				TransliteratorMethods = new TransliteratorMethodsContainer();
-				UnicodeSetMethods = new UnicodeSetMethodsContainer();
-				ResetIcuVersionInfo();
 			}
 		}
 


### PR DESCRIPTION
If you want to continue to use ICU after calling u_cleanup you'll have to call u_init first!

This fixes #174.