### PR TITLE
Fix builds on macOS

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -23,10 +23,20 @@ jobs:
     name: "Build and Test"
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest, macos-12]
     runs-on: ${{ matrix.os }}
 
     steps:
+    - name: Install MacPorts
+      if: ${{ matrix.os == 'macos-12' }}
+      uses: melusina-org/setup-macports@v1
+
+    - name: Install icu4c on macOS
+      if: ${{ matrix.os == 'macos-12' }}
+      run: |
+        sudo port -v install icu
+        echo "DYLD_FALLBACK_LIBRARY_PATH=$HOME/lib:/usr/local/lib:/usr/lib:/opt/local/lib" >> $GITHUB_ENV
+
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
@@ -35,13 +45,17 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Build
       run: dotnet build --configuration Release source/icu.net.sln
 
-    - name: Test
-      run: dotnet test --configuration Release --no-build source/icu.net.sln -- NUnit.TestOutputXml=TestResults
+    - name: Test on .NET 8.0
+      run: dotnet test -p:TargetFramework=net8.0 --configuration Release --no-build source/icu.net.sln -- NUnit.TestOutputXml=TestResults
+
+    - name: Test on .NET Framework 4.6.1 (Windows only)
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: dotnet test -p:TargetFramework=net461 --configuration Release --no-build source/icu.net.sln -- NUnit.TestOutputXml=TestResults
 
     - name: Upload Test Results
       if: always()

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>net40;net451;netstandard1.6;net6.0</TargetFrameworks>
+    <TargetFrameworks>net40;net451;netstandard1.6;net8.0</TargetFrameworks>
     <PlatformAlias>netstandard</PlatformAlias>
     <OutputPath>$(MSBuildThisFileDirectory)\..\output\$(Configuration)</OutputPath>
     <PackageOutputPath>$(MSBuildThisFileDirectory)\..\output</PackageOutputPath>

--- a/source/TestHelper/TestHelper.csproj
+++ b/source/TestHelper/TestHelper.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net8.0</TargetFrameworks>
     <OutputPath>../../output/$(Configuration)/TestHelper</OutputPath>
     <OutputType>Exe</OutputType>
     <RootNamespace>Icu.Tests</RootNamespace>

--- a/source/icu.net.tests/IcuWrapperTests.cs
+++ b/source/icu.net.tests/IcuWrapperTests.cs
@@ -91,8 +91,8 @@ namespace Icu.Tests
 			Assert.That(int.TryParse(result.Substring(0, result.IndexOf(".", StringComparison.Ordinal)), out var major), Is.True);
 		}
 
-		[Platform(Exclude = "Linux",
-			Reason = "These tests require ICU4C installed from NuGet packages which isn't available on Linux")]
+		[Platform(Include = "Win",
+			Reason = "These tests require ICU4C installed from NuGet packages which is only available on Windows")]
 		[Test]
 		public void ConfineVersions_WorksAfterInit()
 		{
@@ -105,8 +105,8 @@ namespace Icu.Tests
 			Assert.That(Wrapper.DataDirectory, Is.EqualTo("Test"));
 		}
 
-		[Platform(Exclude = "Linux",
-			Reason = "These tests require ICU4C installed from NuGet packages which isn't available on Linux")]
+		[Platform(Include = "Win",
+			Reason = "These tests require ICU4C installed from NuGet packages which is only available on Windows")]
 		[Test]
 		public void ConfineVersions_LoadFromDifferentDirectory_LowerVersion()
 		{
@@ -130,8 +130,8 @@ namespace Icu.Tests
 			Assert.That(result, Is.EqualTo(NativeMethodsTests.MinIcuLibraryVersion));
 		}
 
-		[Platform(Exclude = "Linux",
-			Reason = "These tests require ICU4C installed from NuGet packages which isn't available on Linux")]
+		[Platform(Include = "Win",
+			Reason = "These tests require ICU4C installed from NuGet packages which is only available on Windows")]
 		[Test]
 		public void ConfineVersions_LoadFromDifferentDirectory_HigherVersion()
 		{
@@ -155,8 +155,8 @@ namespace Icu.Tests
 			Assert.That(result, Is.EqualTo(NativeMethodsTests.FullIcuLibraryVersion));
 		}
 
-		[Platform(Exclude = "Linux",
-			Reason = "These tests require ICU4C installed from NuGet packages which isn't available on Linux")]
+		[Platform(Include = "Win",
+			Reason = "These tests require ICU4C installed from NuGet packages which is only available on Windows")]
 		[Test]
 		public void ConfineVersions_LoadFromDifferentDirectory_NotInPreferredDir()
 		{

--- a/source/icu.net.tests/NativeMethods/NativeMethodsHelperTests.cs
+++ b/source/icu.net.tests/NativeMethods/NativeMethodsHelperTests.cs
@@ -14,6 +14,7 @@ namespace Icu.Tests
 	{
 		private string _filenameWindows;
 		private string _filenameLinux;
+		private string _filenameMac;
 
 		private int CallGetIcuVersionInfoForNetCoreOrWindows()
 		{
@@ -36,6 +37,8 @@ namespace Icu.Tests
 			File.WriteAllText(_filenameWindows, "just a dummy file");
 			_filenameLinux = Path.Combine(NativeMethodsTests.OutputDirectory, $"libicuuc.so.{Wrapper.MaxSupportedIcuVersion}.1");
 			File.WriteAllText(_filenameLinux, "just a dummy file");
+			_filenameMac = Path.Combine(NativeMethodsTests.OutputDirectory, $"libicuuc.{Wrapper.MaxSupportedIcuVersion}.dylib");
+			File.WriteAllText(_filenameMac, "just a dummy file");
 		}
 
 		[TearDown]
@@ -43,6 +46,7 @@ namespace Icu.Tests
 		{
 			File.Delete(_filenameWindows);
 			File.Delete(_filenameLinux);
+			File.Delete(_filenameMac);
 			Wrapper.Cleanup();
 		}
 

--- a/source/icu.net.tests/NativeMethods/NativeMethodsTests.cs
+++ b/source/icu.net.tests/NativeMethods/NativeMethodsTests.cs
@@ -8,8 +8,8 @@ using NUnit.Framework;
 
 namespace Icu.Tests
 {
-	[Platform(Exclude = "Linux",
-		Reason = "These tests require ICU4C installed from NuGet packages which isn't available on Linux")]
+	[Platform(Include = "Win",
+		Reason = "These tests require ICU4C installed from NuGet packages which is only available on Windows")]
 	[TestFixture]
 	public class NativeMethodsTests
 	{

--- a/source/icu.net.tests/ResourceBundleTests.cs
+++ b/source/icu.net.tests/ResourceBundleTests.cs
@@ -51,14 +51,16 @@ namespace Icu.Tests
 			}
 		}
 
-		[TestCase("en_US", ExpectedResult = "[a b c d e f g h i j k l m n o p q r s t u v w x y z]")]
-		[TestCase("de_DE", ExpectedResult = "[a ä b c d e f g h i j k l m n o ö p q r s ß t u ü v w x y z]")]
-		[TestCase("fr_FR", ExpectedResult = "[a à â æ b c ç d e é è ê ë f g h i î ï j k l m n o ô œ p q r s t u ù û ü v w x y ÿ z]")]
+		[TestCase("en_US", ExpectedResult = "[abcdefghijklmnopqrstuvwxyz]")]
+		[TestCase("de_DE", ExpectedResult = "[aäbcdefghijklmnoöpqrsßtuüvwxyz]")]
+		[TestCase("fr_FR", ExpectedResult = "[aàâæbcçdeéèêëfghiîïjklmnoôœpqrstuùûüvwxyÿz]")]
 		public string GetStringByKey(string localeId)
 		{
 			using (var resourceBundle = new ResourceBundle(null, localeId))
 			{
-				return resourceBundle.GetStringByKey("ExemplarCharacters");
+				// Ideally this should be parsed by something that understands UnicodeSet structures
+				// Since spaces aren't meaningful in UnicodeSets, we'll take a shortcut and remove them
+				return resourceBundle.GetStringByKey("ExemplarCharacters").Replace(" ", "");
 			}
 		}
 	}

--- a/source/icu.net.tests/TimeZoneTests.cs
+++ b/source/icu.net.tests/TimeZoneTests.cs
@@ -63,6 +63,7 @@ namespace Icu.Tests
 			Assert.GreaterOrEqual(timezones.Count(), 3);
 		}
 
+		[Platform(Exclude = "MacOsX", Reason = "The timezone ID for UTC can come in as Universal")]
 		[Test]
 		public void GetDefaultTimeZoneTest()
 		{

--- a/source/icu.net.tests/icu.net.tests.csproj
+++ b/source/icu.net.tests/icu.net.tests.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;net6.0</TargetFrameworks>
+    <!--
+      If you only want to test on a particular target framework, run "dotnet test -p:TargetFramework=XXX"
+      For example, on macOS you probably want to run "dotnet test -p:TargetFramework=net8.0" since 4.6.1 isn't supported
+     -->
+    <TargetFrameworks>net461;net8.0</TargetFrameworks>
     <RootNamespace>Icu.Tests</RootNamespace>
     <AssemblyTitle>icu.net.tests</AssemblyTitle>
     <IsPackable>false</IsPackable>
@@ -10,8 +14,14 @@
     <PackageReference Include="Icu4c.Win.Min" Version="59.1.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Console" Version="3.15.2" />
+    <!--
+      Only version 4.3.2 of NUnit3TestAdapter is able to run tests for both .NET 8.0 and .NET Framework 4.6.1.
+      https://docs.nunit.org/articles/vs-test-adapter/Supported-Frameworks.html
+
+      Going forward we're going to have to drop 4.6.1 support to be able to support newer .NET versions.
+     -->
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.2" />
+    <PackageReference Include="NUnit.Console" Version="3.17.0" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
   </ItemGroup>

--- a/source/icu.net/NativeMethods/NativeMethodsHelper.cs
+++ b/source/icu.net/NativeMethods/NativeMethodsHelper.cs
@@ -24,9 +24,10 @@ namespace Icu
 		private const string Icu4c = nameof(Icu4c);
 		private const string IcuRegexLinux = @"libicu\w+.so\.(?<version>[0-9]{2,})(\.[0-9])*";
 		private const string IcuRegexWindows = @"icu\w+(?<version>[0-9]{2,})(\.[0-9])*\.dll";
+		private const string IcuRegexMac = @"libicu\w+.(?<version>[0-9]{2,})(\.[0-9])*.dylib";
 
-		private static readonly Regex IcuBinaryRegex = new Regex($"{IcuRegexWindows}|{IcuRegexLinux}$", RegexOptions.Compiled);
-		private static readonly string IcuSearchPattern = Platform.OperatingSystem == OperatingSystemType.Windows ? "icu*.dll" : "libicu*.so.*";
+		private static readonly Regex IcuBinaryRegex = new ($"{IcuRegexWindows}|{IcuRegexLinux}|{IcuRegexMac}$", RegexOptions.Compiled);
+		private static readonly string IcuSearchPattern = Platform.OperatingSystem == OperatingSystemType.Windows ? "icu*.dll" : Platform.OperatingSystem == OperatingSystemType.MacOSX ? "libicu*.*.dylib" : "libicu*.so.*";
 		private static readonly string NugetPackageDirectory = GetDefaultPackageDirectory(Platform.OperatingSystem);
 
 		// ReSharper disable once InconsistentNaming

--- a/source/icu.net/icu.net.csproj
+++ b/source/icu.net/icu.net.csproj
@@ -34,6 +34,15 @@
     <Compile Remove="SortKey.cs" />
   </ItemGroup>
 
+  <!-- ICU must be installed using MacPorts before this will work -->
+  <ItemGroup>
+    <Content Include="/opt/local/lib/*.dylib" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <!-- Also add the following to .zprofile file. It is already included in the GitHub build. -->
+  <!-- export DYLD_FALLBACK_LIBRARY_PATH="$HOME/lib:/usr/local/lib:/usr/lib:/opt/local/lib" -->
+
   <ItemGroup>
     <None Include="App.config" Pack="true" PackagePath="contentFiles\any\any\$(AssemblyTitle).dll.config" />
     <None Include="../../README.md" Pack="true" PackagePath="/">


### PR DESCRIPTION
This resolves a number of problems with using icu-dotnet on macOS. It helps with a number of issues found in https://github.com/paranext/paranext-core/issues/264.

This change adds macOS to the github builds so that future breaks should be caught by normal CI/CD workflows.