### PR TITLE
fix invalid Uri error when running in a Single file application

### DIFF
--- a/source/icu.net/NativeMethods/NativeMethods.cs
+++ b/source/icu.net/NativeMethods/NativeMethods.cs
@@ -176,6 +176,12 @@ namespace Icu
 #endif
 #if NET
 				var managedPath = currentAssembly.Location;
+				// If the application is published as a single file, Assembly.Location will be null.
+				// Per the warning https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3000 we should use AppContext.BaseDirectory instead.
+				if (string.IsNullOrEmpty(managedPath))
+				{
+					managedPath = AppContext.BaseDirectory;
+				}
 #else
 				var managedPath = currentAssembly.CodeBase ?? currentAssembly.Location;
 #endif

--- a/source/icu.net/NativeMethods/NativeMethods.cs
+++ b/source/icu.net/NativeMethods/NativeMethods.cs
@@ -176,7 +176,7 @@ namespace Icu
 #endif
 #if NET
 				var managedPath = currentAssembly.Location;
-				// If the application is published as a single file, Assembly.Location will be null.
+				// If the application is published as a single file, Assembly.Location will be an empty string.
 				// Per the warning https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3000 we should use AppContext.BaseDirectory instead.
 				if (string.IsNullOrEmpty(managedPath))
 				{


### PR DESCRIPTION
When publishing a Single file application we would get an error when trying to initlize Icu. This PR fixes that issue.

To test run the following in the TestHelper project
```bash
dotnet publish -r win-x64 --property:PublishSingleFile=true --framework net8.0
```
the resulting exe can be found in `icu-dotnet\output\Release\TestHelper\net8.0\win-x64\publish`, copy in the native ICU dlls to that folder and run that with the following (numbers being the icu version range)
```bash
 .\TestHelper.exe 70 72
```

before this PR you would get this exception:
```
Unhandled exception. System.TypeInitializationException: The type initializer for 'Icu.NativeMethods' threw an exception.
 ---> System.UriFormatException: Invalid URI: The URI is empty.
   at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind, UriCreationOptions& creationOptions)
   at System.Uri..ctor(String uriString)
   at Icu.NativeMethods.get_DirectoryOfThisAssembly() in C:\dev\icu-dotnet\source\icu.net\NativeMethods\NativeMethods.cs:line 175
   at Icu.NativeMethodsHelper.TryGetPathFromAssemblyDirectory() in C:\dev\icu-dotnet\source\icu.net\NativeMethods\NativeMethodsHelper.cs:line 145
   at Icu.NativeMethodsHelper.GetIcuVersionInfoForNetCoreOrWindows() in C:\dev\icu-dotnet\source\icu.net\NativeMethods\NativeMethodsHelper.cs:line 65
   at Icu.NativeMethods.ResetIcuVersionInfo() in C:\dev\icu-dotnet\source\icu.net\NativeMethods\NativeMethods.cs:line 466
   at Icu.NativeMethods..cctor() in C:\dev\icu-dotnet\source\icu.net\NativeMethods\NativeMethods.cs:line 73
   --- End of inner exception stack trace ---
   at Icu.NativeMethods.SetMinMaxIcuVersions(Int32 minVersion, Int32 maxVersion) in C:\dev\icu-dotnet\source\icu.net\NativeMethods\NativeMethods.cs:line 37
   at Icu.Wrapper.ConfineIcuVersions(Int32 minIcuVersion, Int32 maxIcuVersion) in C:\dev\icu-dotnet\source\icu.net\IcuWrapper.cs:line 81
   at Icu.Tests.TestHelper.Main(String[] args) in C:\dev\icu-dotnet\source\TestHelper\TestHelper.cs:line 40
```

this is because `Assembly.Location` returns an empty string. Per the [warning](https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3000), I'm using `AppContext.BaseDirectory` when location returns an empty string.

It would be nice to have an automated test for this, but doing that would require doing something similar to above where we publish a SingleFile project and run it, not sure if that's worth it.