### PR TITLE
Fix small regex bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   UHangulSyllableType, UIndicPositionalCategory, UIndicSyllabicCategory, UIndicConjunctBreak,
   UVerticalOrientation, UIdentifierStatus, UIdentifierType.
 
+### Fixed
+
+- Fixed regex patterns in `NativeMethodsHelper` for Linux (`libicu*.so.*`) and macOS
+  (`libicu*.dylib`): unescaped `.` matched any character instead of a literal dot.
+
 ### Deprecated
 
 - In Character class, added \[Obsolete\] attribute to enum members UDecompositionType.COUNT and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed regex patterns in `NativeMethodsHelper` for Linux (`libicu*.so.*`) and macOS
   (`libicu*.dylib`): unescaped `.` matched any character instead of a literal dot.
+- Fixed `NativeMethodsHelper` combined regex: `$` end-anchor now applies to all three
+  platform alternatives, not only the macOS branch.
+- Fixed `NativeMethodsHelper` regex patch-version segments: `(\.[0-9])*` changed to
+  `(\.[0-9]+)*` to allow multi-digit patch components.
+- Fixed `TimeZoneTests.GetTZVersionTest`: version pattern is now anchored (`^[0-9]{4}[a-z]$`)
+  so it validates the full string rather than a substring.
 
 ### Deprecated
 

--- a/source/icu.net.tests/TimeZoneTests.cs
+++ b/source/icu.net.tests/TimeZoneTests.cs
@@ -102,7 +102,7 @@ namespace Icu.Tests
 		{
 			var version = TimeZone.GetTZDataVersion();
 
-			Assert.True(Regex.IsMatch(version, "[0-9]{4}[a-z]"));
+			Assert.True(Regex.IsMatch(version, "^[0-9]{4}[a-z]$"));
 		}
 
 		[Test]

--- a/source/icu.net/NativeMethods/NativeMethodsHelper.cs
+++ b/source/icu.net/NativeMethods/NativeMethodsHelper.cs
@@ -21,9 +21,9 @@ namespace Icu
 		// ReSharper disable once InconsistentNaming
 		// ReSharper disable once UnusedMember.Local
 		private const string Icu4c = nameof(Icu4c);
-		private const string IcuRegexLinux = @"libicu\w+.so\.(?<version>[0-9]{2,})(\.[0-9])*";
+		private const string IcuRegexLinux = @"libicu\w+\.so\.(?<version>[0-9]{2,})(\.[0-9])*";
 		private const string IcuRegexWindows = @"icu\w+(?<version>[0-9]{2,})(\.[0-9])*\.dll";
-		private const string IcuRegexMac = @"libicu\w+.(?<version>[0-9]{2,})(\.[0-9])*.dylib";
+		private const string IcuRegexMac = @"libicu\w+\.(?<version>[0-9]{2,})(\.[0-9])*\.dylib";
 
 		private static readonly Regex IcuBinaryRegex = new ($"{IcuRegexWindows}|{IcuRegexLinux}|{IcuRegexMac}$", RegexOptions.Compiled);
 		private static readonly string IcuSearchPattern = Platform.OperatingSystem == OperatingSystemType.Windows ? "icu*.dll" : Platform.OperatingSystem == OperatingSystemType.MacOSX ? "libicu*.*.dylib" : "libicu*.so.*";

--- a/source/icu.net/NativeMethods/NativeMethodsHelper.cs
+++ b/source/icu.net/NativeMethods/NativeMethodsHelper.cs
@@ -21,11 +21,11 @@ namespace Icu
 		// ReSharper disable once InconsistentNaming
 		// ReSharper disable once UnusedMember.Local
 		private const string Icu4c = nameof(Icu4c);
-		private const string IcuRegexLinux = @"libicu\w+\.so\.(?<version>[0-9]{2,})(\.[0-9])*";
-		private const string IcuRegexWindows = @"icu\w+(?<version>[0-9]{2,})(\.[0-9])*\.dll";
-		private const string IcuRegexMac = @"libicu\w+\.(?<version>[0-9]{2,})(\.[0-9])*\.dylib";
+		private const string IcuRegexLinux = @"libicu\w+\.so\.(?<version>[0-9]{2,})(\.[0-9]+)*";
+		private const string IcuRegexWindows = @"icu\w+(?<version>[0-9]{2,})(\.[0-9]+)*\.dll";
+		private const string IcuRegexMac = @"libicu\w+\.(?<version>[0-9]{2,})(\.[0-9]+)*\.dylib";
 
-		private static readonly Regex IcuBinaryRegex = new ($"{IcuRegexWindows}|{IcuRegexLinux}|{IcuRegexMac}$", RegexOptions.Compiled);
+		private static readonly Regex IcuBinaryRegex = new ($"(?:{IcuRegexWindows}|{IcuRegexLinux}|{IcuRegexMac})$", RegexOptions.Compiled);
 		private static readonly string IcuSearchPattern = Platform.OperatingSystem == OperatingSystemType.Windows ? "icu*.dll" : Platform.OperatingSystem == OperatingSystemType.MacOSX ? "libicu*.*.dylib" : "libicu*.so.*";
 		private static readonly string NugetPackageDirectory = GetDefaultPackageDirectory(Platform.OperatingSystem);
 


### PR DESCRIPTION
Devin review: https://app.devin.ai/review/sillsdev/icu-dotnet/pull/217

## Claude Change Summary

### `source/icu.net/NativeMethods/NativeMethodsHelper.cs`

- **Unescaped dots** (commit `e997781`): `.so.` and `.dylib` in the Linux and macOS patterns
  used unescaped `.`, matching any character. Escaped to `\.`.
- **Single-digit patch versions** (commit `9a08549`): `(\.[0-9])*` changed to `(\.[0-9]+)*`
  so patch components like `.10` are matched correctly.
- **Broken `$` anchor** (commit `9a08549`): The combined regex `Windows|Linux|Mac$` only
  anchored the macOS alternative. Wrapped in a non-capturing group: `(?:Windows|Linux|Mac)$`.

### `source/icu.net.tests/TimeZoneTests.cs`

- **Unanchored test assertion** (commit `9a08549`): `[0-9]{4}[a-z]` would pass for any string
  containing the pattern. Changed to `^[0-9]{4}[a-z]$` to validate the full value.

### `CHANGELOG.md`

- Entries added under `[Unreleased] ### Fixed` for all four fixes above.