### PR TITLE
feat: include XML documentation in NuGet package (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- NuGet package now includes the XML documentation file, enabling IntelliSense summaries in Visual Studio.
 - In Character class, added all enums from Unicode's uchar.h that were missing:
   UBidiPairedBracketType, UBlockCode, UEastAsianWidth, UPropertyNameChoice, UJoiningType,
   UJoiningGroup, UGraphemeClusterBreak, UWordBreakValues, USentenceBreak, ULineBreak,

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -6,6 +6,7 @@
     <PackageOutputPath>$(MSBuildThisFileDirectory)\..\output</PackageOutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>$(NoWarn);CS1573</NoWarn>
     <Company>SIL Global</Company>
     <Authors>SIL Global</Authors>
     <Copyright>Copyright © 2007-2026 SIL Global</Copyright>

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -6,7 +6,6 @@
     <PackageOutputPath>$(MSBuildThisFileDirectory)\..\output</PackageOutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>$(NoWarn);CS1573</NoWarn>
     <Company>SIL Global</Company>
     <Authors>SIL Global</Authors>
     <Copyright>Copyright © 2007-2026 SIL Global</Copyright>

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -19,7 +19,6 @@ See full changelog at https://github.com/sillsdev/icu-dotnet/blob/master/CHANGEL
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>default</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)/icu.net.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -19,6 +19,7 @@ See full changelog at https://github.com/sillsdev/icu-dotnet/blob/master/CHANGEL
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>default</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)/icu.net.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/source/icu.net/BiDi/BiDi.cs
+++ b/source/icu.net/BiDi/BiDi.cs
@@ -194,9 +194,7 @@ namespace Icu
 			Dispose(false);
 		}
 
-		/// <summary>
-		/// Dispose of managed/unmanaged resources.
-		/// </summary>
+		/// <inheritdoc/>
 		public void Dispose()
 		{
 			Dispose(true);

--- a/source/icu.net/BreakIterators/BreakEnumerator.cs
+++ b/source/icu.net/BreakIterators/BreakEnumerator.cs
@@ -34,6 +34,7 @@ namespace Icu.BreakIterators
 			_breakIterator = null;
 		}
 
+		/// <summary>Finalizer. Logs a debug warning if <see cref="Dispose()"/> was not called.</summary>
 		~BreakEnumerator()
 		{
 			Debug.WriteLineIf(_breakIterator != null, $"Missing Dispose() for {GetType()}");

--- a/source/icu.net/BreakIterators/BreakIterator.cs
+++ b/source/icu.net/BreakIterators/BreakIterator.cs
@@ -454,9 +454,7 @@ namespace Icu
 			return false;
 		}
 
-		/// <summary>
-		/// Dispose of managed/unmanaged resources.
-		/// </summary>
+		/// <inheritdoc/>
 		public void Dispose()
 		{
 			Dispose(true);

--- a/source/icu.net/Character.cs
+++ b/source/icu.net/Character.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Globalization;
 
+#pragma warning disable CS1591
 namespace Icu
 {
 	/// <summary>
@@ -2619,3 +2620,4 @@ namespace Icu
 
 	}
 }
+#pragma warning restore CS1591

--- a/source/icu.net/CodepageConversion.cs
+++ b/source/icu.net/CodepageConversion.cs
@@ -6,6 +6,9 @@ using System.Runtime.InteropServices;
 
 namespace Icu
 {
+	/// <summary>
+	/// Provides utilities for working with ICU codepage/encoding converters.
+	/// </summary>
 	public static class CodepageConversion
 	{
 		/// <summary>

--- a/source/icu.net/Collation/Collator.cs
+++ b/source/icu.net/Collation/Collator.cs
@@ -230,7 +230,7 @@ namespace Icu.Collation
 											  originalString);
 		}
 
-		private static void SetInternalFieldForPublicProperty<T,P>(
+		private static void SetInternalFieldForPublicProperty<T, P>(
 			T instance,
 			string propertyName,
 			string frameworkInternalFieldName,
@@ -366,10 +366,7 @@ namespace Icu.Collation
 
 		#region IDisposable Support
 
-		/// <summary>
-		/// Dispose of managed/unmanaged resources.
-		/// Allow any inheriting classes to dispose of manage
-		/// </summary>
+		/// <inheritdoc/>
 		public void Dispose()
 		{
 			Dispose(true);

--- a/source/icu.net/IcuWrapper.cs
+++ b/source/icu.net/IcuWrapper.cs
@@ -16,7 +16,9 @@ namespace Icu
 	/// </summary>
 	public static class Wrapper
 	{
+		/// <summary>The minimum ICU version supported by this library.</summary>
 		public const int MinSupportedIcuVersion = 44;
+		/// <summary>The maximum ICU version supported by this library.</summary>
 		public const int MaxSupportedIcuVersion = 90;
 
 		#region Public Properties

--- a/source/icu.net/MessageFormatter.cs
+++ b/source/icu.net/MessageFormatter.cs
@@ -50,7 +50,7 @@ namespace Icu
 			Dispose(true);
 		}
 
-		/// <summary>Releases the unmanaged resources used by this instance.</summary>
+		/// <summary>Releases the resources used by MessageFormatter.</summary>
 		/// <param name="disposing"><c>true</c> if called from <see cref="Dispose()"/>; <c>false</c> if called from the finalizer.</param>
 		protected void Dispose(bool disposing)
 		{

--- a/source/icu.net/MessageFormatter.cs
+++ b/source/icu.net/MessageFormatter.cs
@@ -6,6 +6,10 @@ using System.Text;
 
 namespace Icu
 {
+	/// <summary>
+	/// Wraps ICU's MessageFormat, which provides locale-sensitive formatting of messages
+	/// containing dates, times, numbers, and other values.
+	/// </summary>
 	public class MessageFormatter : IDisposable
 	{
 		private IntPtr _Formatter;
@@ -46,6 +50,8 @@ namespace Icu
 			Dispose(true);
 		}
 
+		/// <summary>Releases the unmanaged resources used by this instance.</summary>
+		/// <param name="disposing"><c>true</c> if called from <see cref="Dispose()"/>; <c>false</c> if called from the finalizer.</param>
 		protected void Dispose(bool disposing)
 		{
 			if (disposing)
@@ -59,6 +65,7 @@ namespace Icu
 		}
 		#endregion
 
+		/// <summary>Gets the pattern string of this message formatter.</summary>
 		public string Pattern
 		{
 			get

--- a/source/icu.net/Normalization/Normalizer2.cs
+++ b/source/icu.net/Normalization/Normalizer2.cs
@@ -141,7 +141,7 @@ namespace Icu.Normalization
 		/// characters. In other words, a string containing this character can be normalized by
 		/// processing portions up to this character and after this character independently. This
 		/// is used for iterative normalization. Note that this operation may be significantly
-		/// slower than <see cref="hasBoundaryBefore"/>.
+		/// slower than <see cref="HasBoundaryBefore"/>.
 		/// </summary>
 		/// <param name="codePoint">character to test</param>
 		/// <returns><c>true</c> if c has a normalization boundary after it</returns>

--- a/source/icu.net/RegexMatcher.cs
+++ b/source/icu.net/RegexMatcher.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) 2017 JEPA
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Icu
 {
 	/// <summary>
 	/// Regular Expression Matcher
 	/// </summary>
-	public class RegexMatcher: IDisposable
+	public class RegexMatcher : IDisposable
 	{
 		/// <summary>
 		/// Constants for Regular Expression Match Modes.
@@ -149,9 +146,7 @@ namespace Icu
 			return Matches(-1);
 		}
 
-		/// <summary>
-		/// Dispose of managed/unmanaged resources.
-		/// </summary>
+		/// <inheritdoc/>
 		public void Dispose()
 		{
 			Dispose(true);

--- a/source/icu.net/RegexMatcher.cs
+++ b/source/icu.net/RegexMatcher.cs
@@ -154,7 +154,7 @@ namespace Icu
 		}
 
 		/// <summary>
-		/// Releases the resources used by BreakIterator.
+		/// Releases the resources used by RegexMatcher.
 		/// </summary>
 		/// <param name="disposing">true to release managed and unmanaged
 		/// resources; false to release only unmanaged resources.</param>

--- a/source/icu.net/ResourceBundle.cs
+++ b/source/icu.net/ResourceBundle.cs
@@ -50,6 +50,8 @@ namespace Icu
 			Dispose(true);
 		}
 
+		/// <summary>Releases the unmanaged resources used by this instance.</summary>
+		/// <param name="disposing"><c>true</c> if called from <see cref="Dispose()"/>; <c>false</c> if called from the finalizer.</param>
 		protected void Dispose(bool disposing)
 		{
 			if (disposing)

--- a/source/icu.net/ResourceBundle.cs
+++ b/source/icu.net/ResourceBundle.cs
@@ -50,7 +50,7 @@ namespace Icu
 			Dispose(true);
 		}
 
-		/// <summary>Releases the unmanaged resources used by this instance.</summary>
+		/// <summary>Releases the resources used by ResourceBundle.</summary>
 		/// <param name="disposing"><c>true</c> if called from <see cref="Dispose()"/>; <c>false</c> if called from the finalizer.</param>
 		protected void Dispose(bool disposing)
 		{

--- a/source/icu.net/Timezone/Timezone.cs
+++ b/source/icu.net/Timezone/Timezone.cs
@@ -4,6 +4,9 @@ using System.Runtime.InteropServices;
 
 namespace Icu
 {
+	/// <summary>
+	/// Represents an ICU time zone and provides utilities for querying and converting time zone information.
+	/// </summary>
 	public class TimeZone
 	{
 		private readonly string zoneId;

--- a/source/icu.net/Timezone/USystemTimeZoneType.cs
+++ b/source/icu.net/Timezone/USystemTimeZoneType.cs
@@ -1,11 +1,17 @@
-using System;
-
 namespace Icu
 {
+	/// <summary>
+	/// Specifies the type of system time zones to enumerate, used as a filter in
+	/// <see cref="TimeZone.GetTimeZones(USystemTimeZoneType, string)"/>.
+	/// </summary>
+	/// <seealso href="https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/ucal_8h.html#a246d867677ec1a02775072aa0b5b018a"/>
 	public enum USystemTimeZoneType
 	{
+		/// <summary>Any system zones.</summary>
 		Any,
+		/// <summary>Canonical system zones.</summary>
 		Canonical,
+		/// <summary>Canonical system zones associated with actual locations.</summary>
 		CanonicalLocation,
 	}
 }

--- a/source/icu.net/Transliterator.cs
+++ b/source/icu.net/Transliterator.cs
@@ -289,7 +289,7 @@ namespace Icu
 		/// Transliterate <paramref name="text"/>.
 		/// </summary>
 		/// <param name="text">The text to transliterate</param>
-		/// <<param name="textCapacityMultiplier">The capacity for the buffer that holds the
+		/// <param name="textCapacityMultiplier">The capacity for the buffer that holds the
 		/// transliterated text, expressed as a multiplier of the text length.</param>
 		/// <returns>
 		/// The transliterated text. If the initial buffer overflows, the method retries with a doubled buffer.

--- a/source/icu.net/Transliterator.cs
+++ b/source/icu.net/Transliterator.cs
@@ -8,11 +8,29 @@ using System.Text;
 
 namespace Icu
 {
+	/// <summary>
+	/// Wraps ICU's transliteration engine, which converts text from one script or encoding to another.
+	/// </summary>
 	public class Transliterator : IDisposable
 	{
+		/// <summary>
+		/// Direction constant indicating the direction in a transliterator, e.g., the forward or
+		/// reverse rules of a RuleBasedTransliterator.
+		/// </summary>
+		/// <seealso href="https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/utrans_8h.html#a04f480e9e8e40f0d8067521668dc06ec"/>
 		public enum UTransDirection
 		{
+			/// <summary>
+			/// Transliterates from &lt;source&gt; to &lt;target&gt; for a transliterator with ID
+			/// &lt;source&gt;-&lt;target&gt;. For a transliterator opened using a rule, means
+			/// forward direction rules, e.g., <c>A &gt; B</c>.
+			/// </summary>
 			Forward,
+			/// <summary>
+			/// Transliterates from &lt;target&gt; to &lt;source&gt; for a transliterator with ID
+			/// &lt;source&gt;-&lt;target&gt;. For a transliterator opened using a rule, means
+			/// reverse direction rules, e.g., <c>A &lt; B</c>.
+			/// </summary>
 			Reverse
 		}
 
@@ -343,6 +361,8 @@ namespace Icu
 		}
 
 		#region Disposable pattern
+		/// <summary>Releases the resources used by this instance.</summary>
+		/// <param name="disposing"><c>true</c> if called from <see cref="Dispose()"/>; <c>false</c> if called during finalization.</param>
 		protected virtual void Dispose(bool disposing)
 		{
 			if (disposing)
@@ -351,6 +371,7 @@ namespace Icu
 			}
 		}
 
+		/// <inheritdoc/>
 		public void Dispose()
 		{
 			Dispose(true);

--- a/source/icu.net/Transliterator.cs
+++ b/source/icu.net/Transliterator.cs
@@ -361,7 +361,7 @@ namespace Icu
 		}
 
 		#region Disposable pattern
-		/// <summary>Releases the resources used by this instance.</summary>
+		/// <summary>Releases the resources used by Transliterator.</summary>
 		/// <param name="disposing"><c>true</c> if called from <see cref="Dispose()"/>; <c>false</c> if called during finalization.</param>
 		protected virtual void Dispose(bool disposing)
 		{

--- a/source/icu.net/icu.net.csproj
+++ b/source/icu.net/icu.net.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>icu.net</AssemblyName>
     <Description>icu.net is a C# Wrapper around ICU4C</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="6.0.5" PrivateAssets="all" />

--- a/source/icu.net/icu.net.csproj
+++ b/source/icu.net/icu.net.csproj
@@ -5,6 +5,7 @@
     <Description>icu.net is a C# Wrapper around ICU4C</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1573</NoWarn>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>

--- a/source/icu.net/icu.net.csproj
+++ b/source/icu.net/icu.net.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>icu.net</AssemblyName>
     <Description>icu.net is a C# Wrapper around ICU4C</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Enabled `GenerateDocumentationFile` in `icu.net.csproj` so it emits XML docs.
- Added `.xml` to `AllowedOutputExtensionsInPackageBuildOutputFolder` in `icu.net.csproj` so the XML file is bundled into the NuGet package for every target framework.
- Added some build warning exemptions and fill in the rest of the missing docs.

## Test plan
- [ ] Build the NuGet package and verify the `.xml` file is present alongside the `.dll` in the `lib/` folder for icu.net
- [ ] Reference the package in a test project and confirm IntelliSense summaries appear in Visual Studio

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Devin review: https://app.devin.ai/review/sillsdev/icu-dotnet/pull/221