### PR TITLE
fix: Transliterate retries with larger buffer on overflow (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed `Transliterator.Transliterate` throwing `OverflowException` for characters that expand
+  greatly during transliteration (e.g. U+FDFA ﷺ): the method now retries with a larger buffer
+  on `BUFFER_OVERFLOW_ERROR` instead of immediately throwing.
 - Fixed macOS crash at process exit (.NET 6+): `u_cleanup()` and `NativeLibrary.Free` are now
   skipped on macOS so dyld does not fire ICU's destructor against already-cleaned state. Also
   fixed an independent ordering bug on all platforms: `u_cleanup()` was previously called after

--- a/source/icu.net.tests/TransliteratorTests.cs
+++ b/source/icu.net.tests/TransliteratorTests.cs
@@ -110,19 +110,22 @@ namespace Icu.Tests
 		[Test]
 		public void Transliterate_HighExpansionChar_DefaultMultiplier()
 		{
-			// U+FDFA expands to ~29 Latin chars; a multiplier of 3 gives only 3 UChars
+			// U+FDFA (ﷺ) expands to many Latin chars (e.g., "ṣly̱ ạllh ʿlyh wslm", 19 chars in
+			// ICU 62.1). A multiplier of 3 gives only 3 UChars, so the retry path must kick in.
+			// Exact output is ICU-version-specific.
 			_trans = Transliterator.CreateInstance("Any-Latn");
 			var result = _trans.Transliterate("ﷺ");
-			Assert.That(result, Is.Not.Null.And.Not.Empty);
+			Assert.That(result.Length, Is.GreaterThan(15));
 		}
 
 		[Test]
 		public void Transliterate_MultipleHighExpansionChars_SmallMultiplier()
 		{
-			// Each U+FDFA expands to ~29 Latin chars; multiplier=1 forces the retry path
+			// "ﷺﷺ" = U+FDFA U+FDFA; each expands to many Latin chars (see above test comment).
+			// Setting multiplier=1 forces the retry path.
 			_trans = Transliterator.CreateInstance("Any-Latn");
 			var result = _trans.Transliterate("ﷺﷺ", 1);
-			Assert.That(result, Is.Not.Null.And.Not.Empty);
+			Assert.That(result.Length, Is.GreaterThan(30));
 		}
 
 		[Test]

--- a/source/icu.net.tests/TransliteratorTests.cs
+++ b/source/icu.net.tests/TransliteratorTests.cs
@@ -103,7 +103,8 @@ namespace Icu.Tests
 			const string source = @"김, 국삼";
 
 			_trans = Transliterator.CreateInstance("Any-Latin; Latin-ASCII");
-			Assert.That(() => _trans.Transliterate(source, 1), Throws.InstanceOf<OverflowException>());
+			var result = _trans.Transliterate(source, 1);
+			Assert.That(result, Is.Not.Null.And.Not.Empty);
 		}
 	}
 }

--- a/source/icu.net.tests/TransliteratorTests.cs
+++ b/source/icu.net.tests/TransliteratorTests.cs
@@ -106,5 +106,14 @@ namespace Icu.Tests
 			var result = _trans.Transliterate(source, 1);
 			Assert.That(result, Is.Not.Null.And.Not.Empty);
 		}
+
+		[Test]
+		public void Transliterate_HighExpansionChar_DefaultMultiplier()
+		{
+			// U+FDFA expands to ~29 Latin chars; a multiplier of 3 gives only 3 UChars
+			_trans = Transliterator.CreateInstance("Any-Latn");
+			var result = _trans.Transliterate("ﷺ");
+			Assert.That(result, Is.Not.Null.And.Not.Empty);
+		}
 	}
 }

--- a/source/icu.net.tests/TransliteratorTests.cs
+++ b/source/icu.net.tests/TransliteratorTests.cs
@@ -101,10 +101,10 @@ namespace Icu.Tests
 		public void Transliterate_Overflow()
 		{
 			const string source = @"김, 국삼";
+			const string target = @"gim, gugsam";
 
 			_trans = Transliterator.CreateInstance("Any-Latin; Latin-ASCII");
-			var result = _trans.Transliterate(source, 1);
-			Assert.That(result, Is.Not.Null.And.Not.Empty);
+			Assert.That(_trans.Transliterate(source, 1), Is.EqualTo(target));
 		}
 
 		[Test]
@@ -114,6 +114,22 @@ namespace Icu.Tests
 			_trans = Transliterator.CreateInstance("Any-Latn");
 			var result = _trans.Transliterate("ﷺ");
 			Assert.That(result, Is.Not.Null.And.Not.Empty);
+		}
+
+		[Test]
+		public void Transliterate_MultipleHighExpansionChars_SmallMultiplier()
+		{
+			// Each U+FDFA expands to ~29 Latin chars; multiplier=1 forces the retry path
+			_trans = Transliterator.CreateInstance("Any-Latn");
+			var result = _trans.Transliterate("ﷺﷺ", 1);
+			Assert.That(result, Is.Not.Null.And.Not.Empty);
+		}
+
+		[Test]
+		public void Transliterate_EmptyString()
+		{
+			_trans = Transliterator.CreateInstance("Any-Latin; Latin-ASCII");
+			Assert.That(_trans.Transliterate(string.Empty), Is.EqualTo(string.Empty));
 		}
 	}
 }

--- a/source/icu.net.tests/TransliteratorTests.cs
+++ b/source/icu.net.tests/TransliteratorTests.cs
@@ -111,20 +111,20 @@ namespace Icu.Tests
 		public void Transliterate_HighExpansionChar_DefaultMultiplier()
 		{
 			// U+FDFA (ﷺ) expands to many Latin chars (e.g., "ṣly̱ ạllh ʿlyh wslm", 19 chars in
-			// ICU 62.1). A multiplier of 3 gives only 3 UChars, so the retry path must kick in.
-			// Exact output is ICU-version-specific.
+			// ICU 62.1). The default multiplier of 3 gives only 3 UChars, so the retry pat
+			// must kick in. Exact output is ICU-version-specific.
 			_trans = Transliterator.CreateInstance("Any-Latn");
-			var result = _trans.Transliterate("ﷺ");
+			var result = _trans.Transliterate("\ufdfa");
 			Assert.That(result.Length, Is.GreaterThan(15));
 		}
 
 		[Test]
 		public void Transliterate_MultipleHighExpansionChars_SmallMultiplier()
 		{
-			// "ﷺﷺ" = U+FDFA U+FDFA; each expands to many Latin chars (see above test comment).
+			// U+FDFA U+FDFA (ﷺﷺ); each expands to many Latin chars (see above test comment).
 			// Setting multiplier=1 forces the retry path.
 			_trans = Transliterator.CreateInstance("Any-Latn");
-			var result = _trans.Transliterate("ﷺﷺ", 1);
+			var result = _trans.Transliterate("\ufdfa\ufdfa", 1);
 			Assert.That(result.Length, Is.GreaterThan(30));
 		}
 

--- a/source/icu.net/Transliterator.cs
+++ b/source/icu.net/Transliterator.cs
@@ -292,7 +292,7 @@ namespace Icu
 		/// <<param name="textCapacityMultiplier">The capacity for the buffer that holds the
 		/// transliterated text, expressed as a multiplier of the text length.</param>
 		/// <returns>
-		/// The transliterated text, truncated to a maximum of `text.Length * textCapacityMultiplier` characters.
+		/// The transliterated text. If the initial buffer overflows, the method retries with a doubled buffer.
 		/// </returns>
 		public string Transliterate(string text, int textCapacityMultiplier = 3)
 		{
@@ -300,28 +300,45 @@ namespace Icu
 				throw new ArgumentException(nameof(textCapacityMultiplier));
 
 			var unicodeBytes = Encoding.Unicode.GetBytes(text);
-
-			var textLength = text.Length;
-			var textCapacity = textLength * textCapacityMultiplier;
-			var start = 0;
-			var limit = textLength;
 			const int charSize = sizeof(char);
-
-			Debug.Assert(textCapacity * charSize >= unicodeBytes.Length);
+			var start = 0;
 
 			// it's tempting to use Marshal.SystemDefaultCharSize instead of sizeof(char).
 			// However, on Linux for whatever reason that returns 1 instead of the expected 2.
+			var textCapacity = text.Length * textCapacityMultiplier;
+			Debug.Assert(textCapacity * charSize >= unicodeBytes.Length);
+
 			var textPtr = Marshal.AllocHGlobal(textCapacity * charSize);
-			Marshal.Copy(unicodeBytes, 0, textPtr, unicodeBytes.Length);
+			try
+			{
+				Marshal.Copy(unicodeBytes, 0, textPtr, unicodeBytes.Length);
 
-			NativeMethods.utrans_transUChars(_transliteratorHandle, textPtr, ref textLength,
-				textCapacity, start, ref limit, out var status);
-			ExceptionFromErrorCode.ThrowIfError(status);
+				var textLength = text.Length;
+				var limit = textLength;
+				NativeMethods.utrans_transUChars(_transliteratorHandle, textPtr, ref textLength,
+					textCapacity, start, ref limit, out var status);
 
-			var result = Marshal.PtrToStringUni(textPtr, textLength);
-			Marshal.FreeHGlobal(textPtr);
+				if (status == ErrorCode.BUFFER_OVERFLOW_ERROR)
+				{
+					textCapacity *= 2;
+					var newPtr = Marshal.AllocHGlobal(textCapacity * charSize);
+					Marshal.FreeHGlobal(textPtr);
+					textPtr = newPtr;
+					Marshal.Copy(unicodeBytes, 0, textPtr, unicodeBytes.Length);
 
-			return result;
+					textLength = text.Length;
+					limit = textLength;
+					NativeMethods.utrans_transUChars(_transliteratorHandle, textPtr, ref textLength,
+						textCapacity, start, ref limit, out status);
+				}
+
+				ExceptionFromErrorCode.ThrowIfError(status);
+				return Marshal.PtrToStringUni(textPtr, textLength);
+			}
+			finally
+			{
+				Marshal.FreeHGlobal(textPtr);
+			}
 		}
 
 		#region Disposable pattern

--- a/source/icu.net/Transliterator.cs
+++ b/source/icu.net/Transliterator.cs
@@ -320,7 +320,7 @@ namespace Icu
 
 				if (status == ErrorCode.BUFFER_OVERFLOW_ERROR)
 				{
-					textCapacity *= 2;
+					textCapacity = textLength; // ICU reports the required size on overflow
 					var newPtr = Marshal.AllocHGlobal(textCapacity * charSize);
 					Marshal.FreeHGlobal(textPtr);
 					textPtr = newPtr;

--- a/source/icu.net/Transliterator.cs
+++ b/source/icu.net/Transliterator.cs
@@ -300,13 +300,12 @@ namespace Icu
 				throw new ArgumentException(nameof(textCapacityMultiplier));
 
 			var unicodeBytes = Encoding.Unicode.GetBytes(text);
+			// It's tempting to use Marshal.SystemDefaultCharSize instead of sizeof(char).
+			// However, on Linux (for whatever reason) that returns 1 instead of the expected 2.
 			const int charSize = sizeof(char);
-			var start = 0;
-
-			// it's tempting to use Marshal.SystemDefaultCharSize instead of sizeof(char).
-			// However, on Linux for whatever reason that returns 1 instead of the expected 2.
 			var textCapacity = text.Length * textCapacityMultiplier;
 			Debug.Assert(textCapacity * charSize >= unicodeBytes.Length);
+			var start = 0;
 
 			var textPtr = Marshal.AllocHGlobal(textCapacity * charSize);
 			try

--- a/source/icu.net/Transliterator.cs
+++ b/source/icu.net/Transliterator.cs
@@ -320,7 +320,9 @@ namespace Icu
 
 				if (status == ErrorCode.BUFFER_OVERFLOW_ERROR)
 				{
-					textCapacity = textLength; // ICU reports the required size on overflow
+					// Use the ICU-reported required size, but never less than double the
+					// current capacity in case ICU reports a partial output length.
+					textCapacity = Math.Max(textLength, textCapacity * 2);
 					var newPtr = Marshal.AllocHGlobal(textCapacity * charSize);
 					Marshal.FreeHGlobal(textPtr);
 					textPtr = newPtr;


### PR DESCRIPTION
## Summary
- `Transliterator.Transliterate` now automatically retries with a doubled buffer when ICU reports `BUFFER_OVERFLOW_ERROR`, instead of immediately throwing.
- Characters that expand dramatically during transliteration (e.g. U+FDFA) now work with the default multiplier.

Fixes #159 (including the memory leak observed in a comment)

This fix is technically a breaking change, since `Transliterate` no longer throws an error in situations it used to...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

This fix is technically a breaking change, since `Transliterate` no longer throws an error in situations it used to...

Devin review: https://app.devin.ai/review/sillsdev/icu-dotnet/pull/223