### PR TITLE
Partially restore beta NuGet publishing via CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - In Character class, added \[Obsolete\] attribute to enum members UDecompositionType.COUNT and
   UNumericType.COUNT.
 
+## [3.0.1] - 2025-02-21
+
+### Fixed
+
+- Update CI to use supported Ubuntu and macOS runner versions
+
 ## [3.0.0] - 2024-11-21
 
 ### Added
@@ -371,7 +377,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Change versioning scheme. Previously the versions for the nuget package included
   the ICU version. Now we follow [Semantic Versioning](http://semver.org/).
 
-[Unreleased]: https://github.com/sillsdev/icu-dotnet/compare/v3.0.0...master
+[Unreleased]: https://github.com/sillsdev/icu-dotnet/compare/v3.0.1...HEAD
+[3.0.1]: https://github.com/sillsdev/icu-dotnet/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/sillsdev/icu-dotnet/compare/v2.10.0...v3.0.0
 [2.10.0]: https://github.com/sillsdev/icu-dotnet/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/sillsdev/icu-dotnet/compare/v2.8.1...v2.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,7 +371,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Change versioning scheme. Previously the versions for the nuget package included
   the ICU version. Now we follow [Semantic Versioning](http://semver.org/).
 
-[Unreleased]: https://github.com/sillsdev/icu-dotnet/compare/v2.10.0...master
+[Unreleased]: https://github.com/sillsdev/icu-dotnet/compare/v3.0.0...master
+[3.0.0]: https://github.com/sillsdev/icu-dotnet/compare/v2.10.0...v3.0.0
 [2.10.0]: https://github.com/sillsdev/icu-dotnet/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/sillsdev/icu-dotnet/compare/v2.8.1...v2.9.0
 [2.8.1]: https://github.com/sillsdev/icu-dotnet/compare/v2.8.0...v2.8.1
@@ -393,3 +394,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [2.2.0]: https://github.com/sillsdev/icu-dotnet/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/sillsdev/icu-dotnet/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/sillsdev/icu-dotnet/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/sillsdev/icu-dotnet/compare/40ff102..v2.0.0

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,9 +2,8 @@ assembly-versioning-scheme: MajorMinor
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{env:GITVERSION_BUILD_NUMBER ?? 0}'
 mode: ContinuousDeployment
 branches:
-  master:
+  main:
     label: beta
-    regex: (origin/)?master
   hotfix:
     label: beta
     regex: (origin/)?hotfix[/-]


### PR DESCRIPTION
Fixes #224 (a side-effect of #207)

To accompany this pr, I created a v3.0.1 GitHub release (https://github.com/sillsdev/icu-dotnet/releases/tag/v3.0.1) that coincides with the existing NuGet release (https://www.nuget.org/packages/icu.net/3.0.1).

Devin review: https://app.devin.ai/review/sillsdev/icu-dotnet/pull/225

### Claude pr changes summary (lightly edited)

In GitVersion 6.x, a `master:` key in `GitVersion.yml` does not override the built-in `main` branch config (which has an empty label), so every master push computed a stable `3.0.1` instead of `3.0.1-beta.N`. This caused the accidental stable NuGet publish on 2025-02-21 and an "already exists" warning on every subsequent push. For example: https://github.com/sillsdev/icu-dotnet/actions/runs/26783415322/job/78953895080#step:3:8

**Fix:** rename `master:` → `main:` in `GitVersion.yml` (drops redundant `regex:` too). Also adds the `[3.0.1]` changelog entry and updates compare links.

After this PR merges, master pushes will compute `3.0.2-beta.N`.