### PR TITLE
fix: allow master branch to produce beta versions

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,6 +4,7 @@ mode: ContinuousDeployment
 branches:
   main:
     label: beta
+    mode: ContinuousDelivery
   hotfix:
     label: beta
     regex: (origin/)?hotfix[/-]


### PR DESCRIPTION
`ContinuousDeployment` mode on an `is-main-branch:true` branch silently produces stable versions regardless of the label setting. Overriding to `ContinuousDelivery` causes GitVersion 6.x to apply the beta label as a pre-release, yielding `X.Y.Z-beta.N` from the `master` branch.

This finishes the incomplete fix of #225 

Devin review: https://app.devin.ai/review/sillsdev/icu-dotnet/pull/226