### PR TITLE
docs: update Linux ICU version examples to current distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,15 @@ RUN apt-get update \
 ### Linux
 
 icu-dotnet links with any installed version of ICU shared objects. It is
-recommended to install the version provided by the distribution. As of 2016,
-Ubuntu Trusty uses version ICU 52 and Ubuntu Xenial 55.
+recommended to install the version provided by the distribution. For example:
+
+| OS                      | ICU |
+| ----------------------- | --- |
+| Ubuntu 22.04 (Jammy)    | 70  |
+| Ubuntu 24.04 (Noble)    | 74  |
+| Ubuntu 26.04 (Resolute) | 78  |
+| Debian 12 (Bookworm)    | 72  |
+| Debian 13 (Trixie)      | 76  |
 
 If the version provided by the Linux distribution doesn't match your needs,
 [Microsoft's ICU package](https://www.nuget.org/packages/Microsoft.ICU.ICU4C.Runtime/)


### PR DESCRIPTION
Replace the outdated 2016 Ubuntu references with a table showing ICU versions for current Ubuntu LTS and Debian stable releases.

Before: https://github.com/sillsdev/icu-dotnet#linux
After: https://github.com/sillsdev/icu-dotnet/tree/readme-linux-icu#linux
| OS                      | ICU |
| ----------------------- | --- |
| Ubuntu 22.04 (Jammy)    | 70  |
| Ubuntu 24.04 (Noble)    | 74  |
| Ubuntu 26.04 (Resolute) | 78  |
| Debian 12 (Bookworm)    | 72  |
| Debian 13 (Trixie)      | 76  |

Devin review: https://app.devin.ai/review/sillsdev/icu-dotnet/pull/227